### PR TITLE
Added manifest.json

### DIFF
--- a/freeathome/manifest.json
+++ b/freeathome/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "freeathome",
+  "name": "Busch Jaeger/ABB Free@Home",
+  "documentation": "https://github.com/jheling/freeathome",
+  "config_flow": false,
+  "dependencies": [],
+  "codeowners": ["@jheling"],
+  "requirements": []
+}


### PR DESCRIPTION
I needed a manifest.json file for Home Assistant (v0.107.7) to be able to recognise the freeathome implementation.