### PR TITLE
Added requirements

### DIFF
--- a/freeathome/manifest.json
+++ b/freeathome/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": false,
   "dependencies": [],
   "codeowners": ["@jheling"],
-  "requirements": []
+  "requirements": ['https://github.com/jheling/slixmpp/archive/master.zip#slixmpp==1.4.2.1', 'libnacl==1.7.0']
 }


### PR DESCRIPTION
I've added the requirements, since this file seems to overrule the __init__.py. 

This is noticed when removing the home-assistant docker and starting it again from scratch. 
The alternative is rename the file to something else.