### PR TITLE
Single quote to double.

### DIFF
--- a/freeathome/manifest.json
+++ b/freeathome/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": false,
   "dependencies": [],
   "codeowners": ["@jheling"],
-  "requirements": ['https://github.com/jheling/slixmpp/archive/master.zip#slixmpp==1.4.2.1', 'libnacl==1.7.0']
+  "requirements": ["https://github.com/jheling/slixmpp/archive/master.zip#slixmpp==1.4.2.1", "libnacl==1.7.0"]
 }


### PR DESCRIPTION
Changed single quote to double. To remove logging error.
2020-04-22 22:29:46 ERROR (SyncWorker_2) [homeassistant.loader] Error parsing manifest.json file at /config/custom_components/freeathome/manifest.json: Expecting value: line 8 column 20 (char 223)