### PR TITLE
Pass roomnames to method. Fixes "NameError: name 'roomnames' is not defined"

### DIFF
--- a/freeathome/pfreeathome.py
+++ b/freeathome/pfreeathome.py
@@ -1046,7 +1046,7 @@ class Client(slixmpp.ClientXMPP):
                     station_name = station_basename + '_windstrength'
                     self.sensor_devices[sensor_device] = FahSensor(self, sensor_device, station_name, 'windstrength', state, outputid)
               
-    def scan_panel(self, xmlroot, serialnumber):
+    def scan_panel(self, xmlroot, serialnumber, roomnames):
 
         channels = xmlroot.find('channels')
         if channels is not None:             
@@ -1178,7 +1178,7 @@ class Client(slixmpp.ClientXMPP):
 
                     # 7 inch panel with possible lock controll
                     if device_id == '1038':
-                        self.scan_panel(neighbor, serialnumber)
+                        self.scan_panel(neighbor, serialnumber, roomnames)
 class FreeAtHomeSysApp(object):
     """"  This class connects to the Busch Jeager Free @ Home sysapp
           parameters in configuration.yaml


### PR DESCRIPTION
I'm getting this error on home assistant start after commit e8ae70df55ea887b473fcdc37dffc33540023b58:

```
2020-06-21 11:43:00 ERROR (MainThread) [homeassistant.setup] Error during setup of component freeathome
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/setup.py", line 190, in _async_setup_component
    result = await asyncio.wait_for(task, SLOW_SETUP_MAX_WAIT)
  File "/usr/lib/python3.7/asyncio/tasks.py", line 416, in wait_for
    return fut.result()
  File "/home/homeassistant/.homeassistant/custom_components/freeathome/__init__.py", line 50, in async_setup
    await sysap.find_devices()
  File "/home/homeassistant/.homeassistant/custom_components/freeathome/pfreeathome.py", line 1247, in find_devices
    await self.xmpp.find_devices(self._use_room_names)
  File "/home/homeassistant/.homeassistant/custom_components/freeathome/pfreeathome.py", line 1181, in find_devices
    self.scan_panel(neighbor, serialnumber)
  File "/home/homeassistant/.homeassistant/custom_components/freeathome/pfreeathome.py", line 1070, in scan_panel
    lock_name = lock_name + ' (' + roomnames[floor_id][room_id] + ')'
NameError: name 'roomnames' is not defined
```

In my configuration, `use_room_names` is enabled.
