### PR TITLE
Re-add valve attribute

### DIFF
--- a/freeathome/climate.py
+++ b/freeathome/climate.py
@@ -64,6 +64,13 @@ class FreeAtHomeThermostat(ClimateEntity):
         self.thermostat_device = device
         self._name = self.thermostat_device.name
 
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attr = {"valve":self.current_actuator}
+        return attr
+
     @property
     def name(self):
         """Return the display name of this thermostat."""
@@ -83,6 +90,11 @@ class FreeAtHomeThermostat(ClimateEntity):
     def current_temperature(self):
         """Return the current temperature."""
         return float(self.thermostat_device.current_temperature)
+
+    @property
+    def current_actuator(self):
+        """Return the current heating actuator state."""
+        return float(self.thermostat_device.current_actuator)
 
     @property
     def target_temperature(self):


### PR DESCRIPTION
The `valve` attribute for climate entities was missing in the last versions. It was added in #57 but was (erroneously?) removed in 525630f, presumably due to some kind of deprecation. However, I did not notice any kind of deprecation message in the logs, and the attribute continues to work.