### PR TITLE
Add support for dimming actuator 6-gang

### DIFF
--- a/freeathome/fah/pfreeathome.py
+++ b/freeathome/fah/pfreeathome.py
@@ -596,6 +596,15 @@ class Client(slixmpp.ClientXMPP):
                     LOG.info('Ignoring device with serialnumber %s since has no channels', device_serialnumber)
                     continue
 
+                # There may be a device-level parameter called deviceChannelSelector. Each possible value of that
+                # parameter has a mask attribute. This mask can be used to filter applicable channelSelectors,
+                # see below.
+                device_filter_mask = 0xFFFFFFFF
+                device_channel_selector_parameter = device.find("./parameters/parameter[@deviceChannelSelector='true']")
+                if device_channel_selector_parameter is not None:
+                    parameter_value = device_channel_selector_parameter.find("value").text
+                    device_filter_mask = int(parameter_value, 16) # e.g. '00000001' -> 0x00000001
+
                 # Filter channels based on channelSelector
                 # There is a device-level parameter called channelSelector. Each possible value of that parameter
                 # has a mask attribute. This mask can be used to filter channels that should be active.
@@ -607,16 +616,18 @@ class Client(slixmpp.ClientXMPP):
                 # 2. ch0001 (Push button top): mask 00000002
                 # 3. ch0002 (Push button bottom: mask 00000002
                 # --> In Rocker mode, ch0000 is active, in Push button mode ch0001 and ch0002 is active
-                channel_selector_parameter = device.find("./parameters/parameter[@channelSelector='true']")
-                if channel_selector_parameter is not None:
-                    # See which option user has selected, e.g. '1'
-                    parameter_value = channel_selector_parameter.find("value").text
-                    # Find that option in the list of options
-                    option = channel_selector_parameter.find("./valueEnum/option[@key='{}']".format(parameter_value))
-                    # Get filter mask from mask attribute
-                    filter_mask = int(option.get('mask'), 16) # e.g. '00000001' -> 0x00000001
-                else:
-                    filter_mask = 0xFFFFFFFF
+                filter_mask = 0xFFFFFFFF
+                channel_selector_parameters = device.findall("./parameters/parameter[@channelSelector='true']")
+                for channel_selector_parameter in channel_selector_parameters:
+                    # Check if matchCode matches deviceChannelSelector (see above)
+                    parameter_mask = int(channel_selector_parameter.get("matchCode"), 16)
+                    if parameter_mask & device_filter_mask:
+                        # See which option user has selected, e.g. '1'
+                        parameter_value = channel_selector_parameter.find("value").text
+                        # Find that option in the list of options
+                        option = channel_selector_parameter.find("./valueEnum/option[@key='{}']".format(parameter_value))
+                        # Get filter mask from mask attribute
+                        filter_mask = int(option.get('mask'), 16) # e.g. '00000001' -> 0x00000001
 
                 device_info = {"identifiers": {("freeathome", device_serialnumber)}, "name": device_name, "model": device_model, "sw_version": device_sw_version}
 
@@ -627,8 +638,9 @@ class Client(slixmpp.ClientXMPP):
                     function_id = int(function_id, 16) if (function_id is not None and function_id != '') else None
 
                     # Check if channel matches filter mask
-                    if not int(channel.get("mask"), 16) & filter_mask:
-                        LOG.info('Ignoring serialnumber %s, channel_id %s, function ID %s since it does not match device filter mask %s', device_serialnumber, channel_id, function_id, filter_mask)
+                    channel_mask = int(channel.get("mask"), 16)
+                    if not channel_mask & filter_mask:
+                        LOG.info('Ignoring serialnumber %s, channel_id %s, function ID %s since its channel mask %08x does not match device filter mask %08x', device_serialnumber, channel_id, function_id, channel_mask, filter_mask)
                         continue
 
                     same_location = channel.get('sameLocation')

--- a/freeathome/tests/fixtures/1022_dimming_actuator_6gang.xml
+++ b/freeathome/tests/fixtures/1022_dimming_actuator_6gang.xml
@@ -1,0 +1,1131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project time="20201011223216576" localTime="20201012003216576" timeStamp="733006" sessionId="1297e53a" type="debug" mrhaVersion="2.4.0" mrhaBuild="7586">
+ <strings>
+  <string nameId="FFAE">Dimmaktor 6-fach</string>
+ </strings>
+ <devices>
+  <device isTp="true" domainAddress="1011" individualAddress="0132" nameId="FFAE" profile="0E00" maxAPDULength="37" compilerVersion="007A3CF9" buildNumber="000004D8" iconId="FFFF" protocolVersion="0002" minConfigVersion="0001" deviceFlavor="07" interface="TP" functionId="FEF4" shortSerialNumber="HOG" softwareId="14D8" softwareVersion="2.1240" deviceId="1022" name="Dimming&#x20;actuator&#x20;6gang" serialNumber="ABB701312345" commissioningState="ready" consistencyTag="bf29" copyId="2" progress="100">
+   <attribute name="bitErrors">18</attribute>
+   <attribute name="busVoltage">29.64</attribute>
+   <attribute name="deviceErrors">0</attribute>
+   <attribute name="deviceReboots">4</attribute>
+   <attribute name="operationTime">7885</attribute>
+   <attribute name="parityErrors">16</attribute>
+   <channels>
+    <channel channelId="06A0" maxScenes="10" mask="00000001" nameId="004F" i="ch0000" cid="ABB706A0">
+     <attribute name="displayName">Wohnzimmer Hauptbeleuchtung</attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.49273607748184</attribute>
+     <attribute name="offsetY">0.419230769230769</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="false" singleSink="false">5b9a</address>
+       <address timeSlot="0" primary="false" singleSink="false">f740</address>
+       <address timeSlot="0" primary="false" singleSink="false">8d17</address>
+       <address timeSlot="0" primary="true" singleSink="false">6dfa</address>
+       <address timeSlot="0" primary="false" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>8</value>
+       <address timeSlot="0" primary="false" singleSink="false">2b46</address>
+       <address timeSlot="0" primary="true" singleSink="false">c8cb</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>29</value>
+       <address timeSlot="0" primary="true" singleSink="false">b8ac</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">5d1d</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">200</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">2f15</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">da6d</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>360</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>2</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+    <channel channelId="06A0" maxScenes="10" mask="00000002" nameId="0050" i="ch0001" cid="ABB706A0">
+     <attribute name="displayName">Schlafzimmer Beleuchtung</attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.49273607748184</attribute>
+     <attribute name="offsetY">0.42215088282504</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="false" singleSink="false">1042</address>
+       <address timeSlot="0" primary="false" singleSink="false">f740</address>
+       <address timeSlot="0" primary="false" singleSink="false">8d17</address>
+       <address timeSlot="0" primary="true" singleSink="false">d974</address>
+       <address timeSlot="0" primary="false" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>8</value>
+       <address timeSlot="0" primary="false" singleSink="false">2ab</address>
+       <address timeSlot="0" primary="true" singleSink="false">5c03</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">c754</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">7c4b</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">2736</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1b25</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">c017</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>35</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>360</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>2</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+    <channel channelId="06A0" maxScenes="10" mask="00000004" nameId="0051" i="ch0002" cid="ABB706A0">
+     <attribute name="displayName">Dimmbar Esszimmer </attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.730769191644131</attribute>
+     <attribute name="offsetY">0.735602094240838</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">11bc</address>
+       <address timeSlot="0" primary="false" singleSink="false">f740</address>
+       <address timeSlot="0" primary="false" singleSink="false">8d17</address>
+       <address timeSlot="0" primary="false" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>8</value>
+       <address timeSlot="0" primary="true" singleSink="false">4b62</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">edff</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">c355</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">74f1</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">8f00</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">9925</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>360</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>2</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+    <channel channelId="06A0" maxScenes="10" mask="00000008" nameId="0052" i="ch0003" cid="ABB706A0">
+     <attribute name="displayName">Bad Hauptbeleuchtung</attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.5148480501542723</attribute>
+     <attribute name="offsetY">0.4155189427563057</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">f740</address>
+       <address timeSlot="0" primary="false" singleSink="false">8d17</address>
+       <address timeSlot="0" primary="false" singleSink="false">c706</address>
+       <address timeSlot="0" primary="false" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>8</value>
+       <address timeSlot="0" primary="true" singleSink="false">3482</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">9cec</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">ed02</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">8dcb</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">cbef</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>350</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>2</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+    <channel channelId="06A0" maxScenes="10" mask="00000010" nameId="0053" i="ch0004" cid="ABB706A0">
+     <attribute name="displayName">Wohnwand Beleuchtung</attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.49273607748184</attribute>
+     <attribute name="offsetY">0.0820512820512821</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>1</value>
+       <address timeSlot="0" primary="true" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+       <address timeSlot="0" primary="false" singleSink="false">f740</address>
+       <address timeSlot="0" primary="false" singleSink="false">8d17</address>
+       <address timeSlot="0" primary="false" singleSink="false">910</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>8</value>
+       <address timeSlot="0" primary="true" singleSink="false">ecfc</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>100</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">5eaa</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">b7c5</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">cca</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">824f</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>360</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>2</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+    <channel channelId="06A0" maxScenes="10" mask="00000020" nameId="0054" i="ch0005" cid="ABB706A0">
+     <attribute name="displayName">Terassen Beleuchtung</attribute>
+     <attribute name="floor">00</attribute>
+     <attribute name="functionId">12</attribute>
+     <attribute name="offsetX">0.83054892601432</attribute>
+     <attribute name="offsetY">0.161731555912867</attribute>
+     <attribute name="room">00</attribute>
+     <attribute name="selectedIcon">1</attribute>
+     <functions>
+      <function functionId="0012" nameId="00EC" sensorMatchCode="00000000" actuatorMatchCode="00000001" accessLevel="Enduser" preconfigured="false" isDefault="true" fixed="false" bestMatch="false" name="Dim&#x20;actuator"/>
+     </functions>
+     <inputs>
+      <dataPoint defaultConnection="false" nameId="000B" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0001" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Switch&#x20;On/Off" full="false" i="idp0000">
+       <value>1</value>
+       <address timeSlot="0" primary="true" singleSink="false">22de</address>
+       <address timeSlot="0" primary="false" singleSink="false">f470</address>
+       <address timeSlot="0" primary="false" singleSink="false">2128</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0010" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0010" dpt="0307" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Relative&#x20;Set&#x20;Value" full="false" i="idp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">edda</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0011" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0011" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Absolute&#x20;Set&#x20;Value" full="false" i="idp0002">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000C" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0002" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Timed&#x20;Start/Stop" full="false" i="idp0003">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000D" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0003" dpt="0201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position" full="false" i="idp0004">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="000E" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0004" dpt="1201" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Scene&#x20;Control" full="false" i="idp0005">
+       <value>0</value>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="0012" matchCode="00000001" maxConnections="01" pairingOptional="false" pairingId="0012" dpt="0102" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="true" name="Night" i="idp0006">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">1543</address>
+      </dataPoint>
+      <dataPoint defaultConnection="false" nameId="02BD" matchCode="00000001" maxConnections="20" pairingOptional="false" pairingId="0006" dpt="010A" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Movement&#x20;under&#x20;consideration&#x20;of&#x20;brightness" full="false" i="idp0007">
+       <value>0</value>
+      </dataPoint>
+     </inputs>
+     <outputs>
+      <dataPoint defaultConnection="true" nameId="000F" matchCode="00000001" maxConnections="01" pairingId="0100" dpt="0101" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;On/Off" full="false" i="odp0000">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">e528</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0120" matchCode="00000001" maxConnections="01" pairingId="0110" dpt="0501" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Actual&#x20;Dimming&#x20;Value" full="false" i="odp0001">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">8761</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0014" matchCode="00000001" maxConnections="01" pairingId="0111" dpt="1503" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Info&#x20;Error" full="false" i="odp0002">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">46c9</address>
+      </dataPoint>
+      <dataPoint defaultConnection="true" nameId="0204" matchCode="00000001" maxConnections="01" pairingId="0101" dpt="1464" autoConnectRoom="false" autoConnectFloor="false" autoConnectHouse="false" name="Force-position&#x20;info" full="false" i="odp0003">
+       <value>0</value>
+       <address timeSlot="0" primary="true" singleSink="false">bbb6</address>
+      </dataPoint>
+     </outputs>
+     <parameters>
+      <parameter nameId="00FC" parameterId="00DD" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Type&#x20;of&#x20;load" i="pm0000" optional="false">
+       <valueEnum>
+        <option key="1" nameId="01D8" isDefault="true" name="Automatic&#x20;load&#x20;detection"/>
+        <option key="2" nameId="00FB" isDefault="false" name="Inductive&#x20;load"/>
+        <option key="3" nameId="018A" isDefault="false" name="Dimable&#x20;LED/CFL"/>
+        <option key="4" nameId="00FA" isDefault="false" name="Incandescent&#x20;lamp"/>
+        <option key="5" nameId="0539" isDefault="false" name="LED&#x20;trailing&#x20;edge"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="018B" parameterId="0004" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Minimum&#x20;brightness" i="pm0001" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="50" minValue="1" defaultValue="1"/>
+       <value>1</value>
+      </parameter>
+      <parameter nameId="01F4" parameterId="0005" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;day" i="pm0002" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="01F5" parameterId="0012" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0501" visible="true" writable="true" name="Maximum&#x20;switch-on&#x20;brightness,&#x20;night" i="pm0003" optional="false">
+       <valueUnsigned factor="2.55" stepWidth="1" maxValue="100" minValue="10" defaultValue="100"/>
+       <value>100</value>
+      </parameter>
+      <parameter nameId="016D" parameterId="0015" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="0705" visible="true" writable="true" name="Autonomous&#x20;switch&#x20;off&#x20;time&#x20;duration" i="pm0004" optional="false">
+       <valueUnsigned factor="1" stepWidth="10" maxValue="1800" minValue="30" defaultValue="360"/>
+       <value>360</value>
+      </parameter>
+      <parameter nameId="022F" parameterId="0029" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="false" matchCode="00000001" dpt="1464" visible="true" writable="true" name="Switch-on&#x20;mode" i="pm0005" optional="false">
+       <valueEnum>
+        <option key="1" nameId="0239" isDefault="true" name="Last&#x20;brightness"/>
+        <option key="2" nameId="018C" isDefault="false" name="Maximum&#x20;brightness"/>
+       </valueEnum>
+       <value>1</value>
+      </parameter>
+     </parameters>
+     <scenes>
+      <scene active="false" sceneNumber="0" i="sc0000">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0001">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0002">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0003">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0004">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0005">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0006">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0007">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0008">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc0009">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000A">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000B">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000C">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000D">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000E">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+      <scene active="false" sceneNumber="0" i="sc000F">
+       <storedDataPoint pairingId="110">
+        <value>0</value>
+       </storedDataPoint>
+      </scene>
+     </scenes>
+    </channel>
+   </channels>
+   <parameters>
+    <parameter channelSelector="false" deviceChannelSelector="true" nameId="02A2" parameterId="0038" accessLevel="Enduser" dependencyId="FFFF" wizardOnly="true" matchCode="FFFFFFFF" dpt="1503" visible="false" writable="false" name="Device&#x20;channel&#x20;selector" i="pm0000" optional="false">
+     <valueUnsigned factor="1" stepWidth="1" maxValue="4294967295" minValue="0" defaultValue="0"/>
+     <value>805306367</value>
+    </parameter>
+    <parameter channelSelector="true" deviceChannelSelector="false" nameId="003B" parameterId="000C" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="10000000" dpt="14C8" visible="true" writable="true" name="Channel&#x20;selector" i="pm0001" optional="false">
+     <valueEnum>
+      <option key="1" nameId="003C" isDefault="true" mask="0000000F" name="Ⓐ,&#x20;Ⓑ,&#x20;Ⓒ,&#x20;Ⓓ"/>
+      <option key="2" nameId="003D" isDefault="false" mask="00000007" name="Ⓐ+Ⓑ,&#x20;Ⓒ,Ⓓ"/>
+      <option key="3" nameId="003E" isDefault="false" mask="00000003" name="Ⓐ+Ⓑ,&#x20;Ⓒ+Ⓓ"/>
+      <option key="4" nameId="003F" isDefault="false" mask="00000803" name="Ⓐ+Ⓑ+Ⓒ,&#x20;Ⓓ"/>
+      <option key="5" nameId="0040" isDefault="false" mask="00000001" name="Ⓐ+Ⓑ+Ⓒ+Ⓓ"/>
+     </valueEnum>
+     <value>1</value>
+    </parameter>
+    <parameter channelSelector="true" deviceChannelSelector="false" nameId="003B" parameterId="000C" accessLevel="Installer" dependencyId="FFFF" wizardOnly="false" matchCode="20000000" dpt="14C8" visible="true" writable="true" name="Channel&#x20;selector" i="pm0002" optional="false">
+     <valueEnum>
+      <option key="1" nameId="052C" isDefault="true" mask="0000003F" name="Ⓐ,&#x20;Ⓑ,&#x20;Ⓒ,&#x20;Ⓓ,&#x20;Ⓔ,&#x20;Ⓕ"/>
+      <option key="2" nameId="052D" isDefault="false" mask="0000001F" name="Ⓐ+Ⓑ,&#x20;Ⓒ,&#x20;Ⓓ,&#x20;Ⓔ,&#x20;Ⓕ"/>
+      <option key="3" nameId="052F" isDefault="false" mask="0000000F" name="Ⓐ+Ⓑ+Ⓒ,&#x20;Ⓓ,&#x20;Ⓔ,&#x20;Ⓕ"/>
+      <option key="4" nameId="052E" isDefault="false" mask="00000007" name="Ⓐ+Ⓑ,&#x20;Ⓒ+Ⓓ,&#x20;Ⓔ+Ⓕ"/>
+      <option key="5" nameId="0530" isDefault="false" mask="00000003" name="Ⓐ+Ⓑ+Ⓒ,&#x20;Ⓓ+Ⓔ+Ⓕ"/>
+      <option key="6" nameId="0531" isDefault="false" mask="00000001" name="Ⓐ+Ⓑ+Ⓒ+Ⓓ+Ⓔ+Ⓕ"/>
+     </valueEnum>
+     <value>1</value>
+    </parameter>
+   </parameters>
+   <dicts/>
+  </device>
+ </devices>
+</project>

--- a/freeathome/tests/test_light.py
+++ b/freeathome/tests/test_light.py
@@ -170,3 +170,23 @@ class TestDimmer:
         light = next((el for el in devices if el.lookup_key == "BEED82AC0001/ch0000"))
 
         assert light.name == "Arbeitsfläche"
+
+@patch("fah.pfreeathome.Client.get_config", return_value=load_fixture("1022_dimming_actuator_6gang.xml"))
+class TestDimmer6Gang:
+    async def test_light(self, _):
+        client = get_client()
+        await client.find_devices(True)
+
+        devices = client.get_devices("light")
+        assert len(devices) == 6
+        light = next((el for el in devices if el.lookup_key == "ABB701312345/ch0005"))
+
+        # Test attributes
+        assert light.name == "Terassen Beleuchtung (room1)"
+        assert light.serialnumber == "ABB701312345"
+        assert light.channel_id == "ch0005"
+        assert light.device_info["identifiers"] == {("freeathome", "ABB701312345")}
+        assert light.device_info["name"] == "Dimmaktor 6-fach (ABB701312345)"
+        assert light.device_info["model"] == "Dimmaktor 6-fach"
+        assert light.device_info["sw_version"] == "2.1240"
+        assert light.is_on() == False


### PR DESCRIPTION
Fixes #78

I'm not 100% sure what happens here. For some devices, there seems to be an additional parameter with `deviceChannelSelector="true"` that filters the `channelSelector`s to use. This works perfectly for the mentioned device, and all tests are green. However, this is the first time I've seen a device with `deviceChannelSelector="true"`, and I may not have fully grasped its meaning, so this is a bit of unchartered territory here.