### PR TITLE
Add configuration URL to devices

### DIFF
--- a/freeathome/fah/pfreeathome.py
+++ b/freeathome/fah/pfreeathome.py
@@ -705,7 +705,13 @@ class Client(slixmpp.ClientXMPP):
                         # Get filter mask from mask attribute
                         filter_mask = int(option.get('mask'), 16) # e.g. '00000001' -> 0x00000001
 
-                device_info = {"identifiers": {("freeathome", device_serialnumber)}, "name": device_name, "model": device_model, "sw_version": device_sw_version}
+                device_info = {
+                        "configuration_url": "http://{}/".format(self._host),
+                        "identifiers": {("freeathome", device_serialnumber)},
+                        "name": device_name,
+                        "model": device_model,
+                        "sw_version": device_sw_version,
+                        }
 
                 for channel in channels_xml.findall('channel'):
                     channel_id = channel.get('i')


### PR DESCRIPTION
Since Home Assistant 2021.11.0, integrations can add a configuration URL to devices that link to Web UIs etc. of devices. See [this blog post](https://developers.home-assistant.io/blog/2021/10/26/config-entity/#device-configuration-url).

![grafik](https://user-images.githubusercontent.com/22068/140186574-c0e165d4-a93f-41f2-9baf-eaa1bedfefaf.png)
