### PR TITLE
Fire on event for binary_sensor on every press

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ freeathome:
 ```  
 
 ## Events
-Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire an event when pressed. The event type is freeathome_event and contains the following actuator's information:
+Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire an event when pressed. The event type is `freeathome_event` and contains the following actuator's information:
 
 | Key          | Type   | Example                                     |
 |--------------|--------|---------------------------------------------|
@@ -43,7 +43,7 @@ Actuators that are exposed in Home Assistant as binary sensors (typically wall s
 
 The event fires regardless of the state of the binary sensory in Home Assistant and Free@Home. Each time the wall switch is pressed, the event fires.
 
-These events can be used in automations, for example to turn on a light every time the actuator's "on" button is pressed:
+These events can be used in automations. For example to turn on a light every time the actuator's "on" button is pressed:
 ```
 trigger:
   - platform: event

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ freeathome:
   use_room_names: <This is optional, if True then combine the device names with the rooms>
 ```  
 
+## Events
+Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire an event when pressed. The event type is freeathome_event and contains the following actuator's information:
+
+| Key          | Type   | Example                                     |
+|--------------|--------|---------------------------------------------|
+| name         | string | Actuator Hallway                            |
+| serialnumber | string | ABB700CE9999                                |
+| unique_id    | string | ABB700CE9999/ch0000                         |
+| state        | bool   | true for on / false for off                 |
+| command      | string | "pressed" is the only option at this moment |
+
+The event fires regardless of the state of the binary sensory in Home Assistant and Free@Home. Each time the wall switch is pressed, the event fires.
+
+These events can be used in automations, for example to turn on a light every time the actuator's "on" button is pressed:
+```
+trigger:
+  - platform: event
+    event_type: freeathome_event
+    event_data:
+      unique_id: ABB700CE9999/ch0000
+      command: pressed
+      state: true
+action:
+  - service: light.turn_on
+    target:
+      entity_id:
+      - light.nice_lamp
+```
+
+
 ## Debugging
 
 If one of your devices does not work, feel free to open an issue. Please provide some debugging information about your setup. In order to add new devices, please also send a copy of your free@home device XML configuration as well as some status updates. See below how to obtain both.

--- a/freeathome/binary_sensor.py
+++ b/freeathome/binary_sensor.py
@@ -78,4 +78,4 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
             "state"       : self._state,
             "command"     : "pressed"
         }
-        self._hass.bus.fire("freeathome_event", eventdata)
+        self._hass.bus.async_fire("freeathome_event", eventdata)

--- a/freeathome/binary_sensor.py
+++ b/freeathome/binary_sensor.py
@@ -15,7 +15,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices, discovery_inf
     devices = fah.get_devices('binary_sensor')
 
     for device_object in devices:
-        async_add_devices([FreeAtHomeBinarySensor(device_object)])
+        async_add_devices([FreeAtHomeBinarySensor(device_object,hass)])
 
 
 class FreeAtHomeBinarySensor(BinarySensorEntity):
@@ -23,11 +23,13 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
     _name = ''
     binary_device = None
     _state = None
+    _hass = None
 
-    def __init__(self, device):
+    def __init__(self, device, hass):
         self.binary_device = device
         self._name = self.binary_device.name
         self._state = (self.binary_device.state == '1')
+        self._hass = hass
 
     @property
     def name(self):
@@ -65,4 +67,15 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
 
     async def async_update(self):
         """Retrieve latest state."""
+
         self._state = (self.binary_device.state == '1')
+        _LOGGER.info('update sensor')
+
+        eventdata = {
+            "name"        : self._name,
+            "serialnumber": self.binary_device.serialnumber,
+            "unique_id"   : self.unique_id,
+            "state"       : self._state,
+            "command"     : "pressed"
+        }
+        self._hass.bus.fire("freeathome_event", eventdata)


### PR DESCRIPTION
Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire an event when pressed. The event type is `freeathome_event` and contains the following actuator's information:

| Key          | Type   | Example                                     |
|--------------|--------|---------------------------------------------|
| name         | string | Actuator Hallway                            |
| serialnumber | string | ABB700CE9999                                |
| unique_id    | string | ABB700CE9999/ch0000                         |
| state        | bool   | true for on / false for off                 |
| command      | string | "pressed" is the only option at this moment |

The event fires regardless of the state of the binary sensory in Home Assistant and Free@Home. Each time the wall switch is pressed, the event fires.

These events can be used in automations. For example to turn on a light every time the actuator's "on" button is pressed:
```
trigger:
  - platform: event
    event_type: freeathome_event
    event_data:
      unique_id: ABB700CE9999/ch0000
      command: pressed
      state: true
action:
  - service: light.turn_on
    target:
      entity_id:
      - light.nice_lamp
```

Addresses issue #26 