### PR TITLE
Prepare for Home Assistant 2022.1.0 release

### DIFF
--- a/custom_components/freeathome/climate.py
+++ b/custom_components/freeathome/climate.py
@@ -78,7 +78,7 @@ class FreeAtHomeThermostat(ClimateEntity):
 
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         attr = {"valve":self.current_actuator,"temperature_correction":self.temperature_correction}
         return attr

--- a/custom_components/freeathome/climate.py
+++ b/custom_components/freeathome/climate.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (HVAC_MODE_HEAT_COOL, HVAC_MODE_OFF,
                                                     SUPPORT_PRESET_MODE,
                                                     SUPPORT_TARGET_TEMPERATURE)
-from homeassistant.const import (ATTR_TEMPERATURE, DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS)
+from homeassistant.const import (ATTR_TEMPERATURE, TEMP_CELSIUS)
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 
 from .const import DOMAIN

--- a/custom_components/freeathome/config_flow.py
+++ b/custom_components/freeathome/config_flow.py
@@ -47,10 +47,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """ free@home found thru zeroconf """    
     async def async_step_zeroconf(self, zeroconf_info):
         """ Handle zeroconf discovery. """
-        if not zeroconf_info.get("name", "").startswith("free@home"):
+        if not zeroconf_info.name.startswith("free@home"):
             return self.async_abort(reason="not_free@home")
 
-        friendly_name = zeroconf_info["name"].split(":",1)[1].split(".",1)[0]  
+        friendly_name = zeroconf_info.name.split(":",1)[1].split(".",1)[0]  
 
         await self.async_set_unique_id(zeroconf_info["host"])
         self._abort_if_unique_id_configured()

--- a/custom_components/freeathome/cover.py
+++ b/custom_components/freeathome/cover.py
@@ -113,7 +113,7 @@ class FreeAtHomeCover(CoverEntity):
         return self.cover_device.get_cover_tilt_position()
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return {
                 "forced_position": self.cover_device.get_forced_cover_position(),

--- a/custom_components/freeathome/manifest.json
+++ b/custom_components/freeathome/manifest.json
@@ -7,5 +7,6 @@
   "dependencies": [],
   "codeowners": ["@jheling"],
   "requirements": ["slixmpp==1.5.1", "libnacl==1.7.0"],
+  "iot_class": "local_push",
   "zeroconf": ["_http._tcp.local."]
 }

--- a/custom_components/freeathome/sensor.py
+++ b/custom_components/freeathome/sensor.py
@@ -1,9 +1,8 @@
 ''' Support for Free@Home Sensor devices like temperature sensors, lux sensors '''
 import logging
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
     SPEED_KILOMETERS_PER_HOUR,
     TEMP_CELSIUS,
     )
@@ -19,7 +18,7 @@ SENSOR_TYPES = {
         "Temperature",
         TEMP_CELSIUS,
         "mdi:thermometer",
-        DEVICE_CLASS_TEMPERATURE,
+        SensorDeviceClass.TEMPERATURE,
     ],
     "windstrength": [
         "Wind Strength",
@@ -36,7 +35,7 @@ SENSOR_TYPES = {
         "Illumination",
         "lux",
         None,
-        DEVICE_CLASS_ILLUMINANCE],
+        SensorDeviceClass.ILLUMINANCE],
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Busch Jaeger/ABB Free@Home",
-    "render_readme": true
+    "render_readme": true,
+    "homeassistant": "2022.1.0b0"
 }


### PR DESCRIPTION
This fixes various deprecation warnings that will occur with Home Assistant 2022.1.0, which is not yet released. Since this is a breaking change, I will keep this PR as a draft until the new version is released next year.

See https://rc.home-assistant.io/blog/2021/12/03/release-202112/#updates-for-custom-integration-developers, the relevant changes are also linked in the commit messages.