### PR TITLE
Replace libnacl with pynacl

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ Many thanks to Tho85 for building future proof, function based components
 Thanks to Foti for testing the cover device!
 Thanks to Lasse Magnussen for the climate device!
 Thanks to Nadir for testing the weather station
+Thanks to jfindlay for making the the pure_pynacl library available: https://github.com/jfindlay/pure_pynacl

--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ Thanks to Foti for testing the cover device!
 Thanks to Lasse Magnussen for the climate device!
 Thanks to Nadir for testing the weather station
 Thanks to jfindlay for making the the pure_pynacl library available: https://github.com/jfindlay/pure_pynacl
+Thanks to jeroen84 for the PyNaCl implementation

--- a/custom_components/freeathome/fah/clientscramhandler.py
+++ b/custom_components/freeathome/fah/clientscramhandler.py
@@ -1,5 +1,5 @@
-import hashlib, binascii
-import libnacl
+import hashlib
+from nacl.utils import random
 import base64
 import hmac
 import logging
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class ClientScramHandler:
     def createClientFirst(self, text):
 
-        buf = libnacl.randombytes_buf(32)
+        buf = random(32)
         if buf is None or len(buf) != 32:
             raise Exception("Could not generate random bytes")
 

--- a/custom_components/freeathome/fah/clientscramhandler.py
+++ b/custom_components/freeathome/fah/clientscramhandler.py
@@ -8,30 +8,35 @@ log = logging.getLogger(__name__)
 
 
 class ClientScramHandler:
-
     def createClientFirst(self, text):
 
         buf = libnacl.randombytes_buf(32)
         if buf is None or len(buf) != 32:
-            raise Exception('Could not generate random bytes')
+            raise Exception("Could not generate random bytes")
 
-        N = str(base64.b64encode(buf), 'utf-8')
-        self.scram = 'n,,n=' + text + ',r=' + N
+        N = str(base64.b64encode(buf), "utf-8")
+        self.scram = "n,,n=" + text + ",r=" + N
 
         return self.scram
 
     def createClientFinal(self):
-        clientFinalMessageBare = 'c=biws,r=' + self.serverNonce
-        self.authmessage = self.scram[3:] + "," + self.serverChallengeResponse + "," + clientFinalMessageBare
+        clientFinalMessageBare = "c=biws,r=" + self.serverNonce
+        self.authmessage = (
+            self.scram[3:]
+            + ","
+            + self.serverChallengeResponse
+            + ","
+            + clientFinalMessageBare
+        )
 
         clientSignature = self.createClientSignature(self.clientKey)
         if clientSignature is None:
-            raise Exception('Failed to create client signature')
+            raise Exception("Failed to create client signature")
 
         clientSignature = self.byte_xor(clientSignature, self.clientKey)
 
-        Q = str(base64.b64encode(clientSignature), 'utf-8')
-        clientFinalMessageBare += ',p=' + Q
+        Q = str(base64.b64encode(clientSignature), "utf-8")
+        clientFinalMessageBare += ",p=" + Q
         return clientFinalMessageBare
 
     def byte_xor(self, ba1, ba2):
@@ -40,98 +45,114 @@ class ClientScramHandler:
     def setServerFirst(self, response, password):
         self.serverChallengeResponse = response
 
-        self.serverNonce = self.searchItem(self.serverChallengeResponse, 'r')
+        self.serverNonce = self.searchItem(self.serverChallengeResponse, "r")
 
-        salt_string = self.searchItem(self.serverChallengeResponse, 's')
+        salt_string = self.searchItem(self.serverChallengeResponse, "s")
 
-        iteration_string = self.searchItem(self.serverChallengeResponse, 'i')
+        iteration_string = self.searchItem(self.serverChallengeResponse, "i")
 
-        if len(self.serverNonce) == 0 or len(salt_string) == 0 or len(iteration_string) == 0:
-            raise Exception('Missing one or more parameters in SCRAM-SHA challenge')
+        if (
+            len(self.serverNonce) == 0
+            or len(salt_string) == 0
+            or len(iteration_string) == 0
+        ):
+            raise Exception("Missing one or more parameters in SCRAM-SHA challenge")
 
         if len(salt_string) < 32:
-            raise Exception('setServerFirst: salt is too short')
+            raise Exception("setServerFirst: salt is too short")
 
         self.iterations = int(iteration_string)
-        if self.iterations is None or self.iterations < 4096 or self.iterations > 600000:
-            raise Exception('Invalid iteration parameter in SCRAM-SHA challenge')
+        if (
+            self.iterations is None
+            or self.iterations < 4096
+            or self.iterations > 600000
+        ):
+            raise Exception("Invalid iteration parameter in SCRAM-SHA challenge")
 
         self.salt = base64.b64decode(salt_string)
         if self.salt is None or len(self.salt) < 32:
-            raise Exception('Failed to decode s parameter of SCRAM-SHA challenge')
+            raise Exception("Failed to decode s parameter of SCRAM-SHA challenge")
 
         self.clientKey = self.createClientKey(password)
         if self.clientKey is None or len(self.clientKey) == 0:
-            raise Exception('Failed to create clientKey')
+            raise Exception("Failed to create clientKey")
 
         self.serverKey = self.createServerKey(password)
         if self.serverKey is None or len(self.serverKey) == 0:
-            raise Exception('Failed to create serverKey')
+            raise Exception("Failed to create serverKey")
 
     def setServerFinal(self, X):
 
-        Y = bytes(self.searchItem(X, 'v'), 'utf-8')
-        if Y == '':
-            raise Exception('setServerFinal: Missing v parameter')
+        Y = bytes(self.searchItem(X, "v"), "utf-8")
+        if Y == "":
+            raise Exception("setServerFinal: Missing v parameter")
 
-        bb = hmac.new(self.serverKey, bytes(self.authmessage, 'utf-8'), digestmod=hashlib.sha256).digest()
+        bb = hmac.new(
+            self.serverKey, bytes(self.authmessage, "utf-8"), digestmod=hashlib.sha256
+        ).digest()
         if bb is None or len(bb) <= 0:
-            raise Exception('setServerFinal: Failed to calculate HMAC')
+            raise Exception("setServerFinal: Failed to calculate HMAC")
 
         ba = base64.b64encode(bb)
 
         if Y != ba:
-            raise Exception('Failed to verify server SCRAM-SHA signature')
+            raise Exception("Failed to verify server SCRAM-SHA signature")
 
     def searchItem(self, scram_string, id_name):
         if len(scram_string) < 2:
-            return ''
+            return ""
 
-        if scram_string[0] == id_name and scram_string[1] == '=':
+        if scram_string[0] == id_name and scram_string[1] == "=":
             bc = 0
         else:
-            bc = scram_string.find(',' + id_name + '=')
+            bc = scram_string.find("," + id_name + "=")
             if bc == -1:
-                return ''
+                return ""
 
             bc += 1
 
-        bd = scram_string.find(',', bc)
+        bd = scram_string.find(",", bc)
         if bd == -1:
             bd = len(scram_string)
 
-        return scram_string[bc + 2: bd]
+        return scram_string[bc + 2 : bd]
 
     def createClientKey(self, password):
-        bj = hashlib.pbkdf2_hmac('sha256', bytes(password, 'utf8'), self.salt, self.iterations)
+        bj = hashlib.pbkdf2_hmac(
+            "sha256", bytes(password, "utf8"), self.salt, self.iterations
+        )
         if bj is None or len(bj) <= 0:
-            raise Exception('__createClientKey: PBKDF2_HMAC_SHA256 failed')
+            raise Exception("__createClientKey: PBKDF2_HMAC_SHA256 failed")
 
-        bi = 'Client Key'.encode()
+        bi = "Client Key".encode()
         bg = hmac.new(bj, bi, digestmod=hashlib.sha256).digest()
 
         if bg is None or len(bg) <= 0:
-            raise Exception('__createClientKey: HMAC failed')
+            raise Exception("__createClientKey: HMAC failed")
 
         return bg
 
     def createServerKey(self, password):
-        bn = hashlib.pbkdf2_hmac('sha256', bytes(password, 'utf8'), self.salt, self.iterations)
+        bn = hashlib.pbkdf2_hmac(
+            "sha256", bytes(password, "utf8"), self.salt, self.iterations
+        )
         if bn is None or len(bn) <= 0:
-            raise Exception('__createServerKey: PBKDF2_HMAC_SHA256 failed')
+            raise Exception("__createServerKey: PBKDF2_HMAC_SHA256 failed")
 
-        bm = 'Server Key'.encode()
+        bm = "Server Key".encode()
         bk = hmac.new(bn, bm, digestmod=hashlib.sha256).digest()
 
         if bk is None or len(bk) <= 0:
-            raise Exception('__createServerKey: HMAC failed')
+            raise Exception("__createServerKey: HMAC failed")
 
         return bk
 
     def createClientSignature(self, bq):
         bp = hashlib.sha256(bq).digest()
-        bo = hmac.new(bp, bytes(self.authmessage, 'utf8'), digestmod=hashlib.sha256).digest()
+        bo = hmac.new(
+            bp, bytes(self.authmessage, "utf8"), digestmod=hashlib.sha256
+        ).digest()
         if bo is None or len(bo) <= 0:
-            raise Exception('Failed to create client signature')
+            raise Exception("Failed to create client signature")
 
         return bo

--- a/custom_components/freeathome/fah/crypto.py
+++ b/custom_components/freeathome/fah/crypto.py
@@ -10,8 +10,7 @@ from .constants import General, Result, FAHMessage
 log = logging.getLogger(__name__)
 
 
-class Crypto():
-
+class Crypto:
     def __init__(self, jid, password, iterations, salt):
         self.jid = jid
         self.password = password
@@ -29,9 +28,11 @@ class Crypto():
         self.publicKey = keypair[0]
         self.secretKey = keypair[1]
 
-    # complete 
+    # complete
     def generateSharedKey(self):
-        return hashlib.pbkdf2_hmac('sha256', bytes(self.password, 'utf-8'), self.salt, self.iterations)
+        return hashlib.pbkdf2_hmac(
+            "sha256", bytes(self.password, "utf-8"), self.salt, self.iterations
+        )
 
         # complete
 
@@ -49,12 +50,12 @@ class Crypto():
         generic_hash = libnacl.crypto_generichash(message, key)
 
         if generic_hash is None:
-            raise Error('generic hash undefined')
+            raise Error("generic hash undefined")
 
         token = libnacl.crypto_onetimeauth(self.publicKey, generic_hash)
 
         if len(self.publicKey) + len(key) + len(token) != 64:
-            raise Error('Unexpected token size')
+            raise Error("Unexpected token size")
 
         authenticator = bytearray(self.publicKey)
         authenticator.extend(key)
@@ -65,30 +66,35 @@ class Crypto():
     def completeKeyExchange(self, data):
 
         if len(data) < 8:
-            raise Error('Invalid KeyExchange response')
+            raise Error("Invalid KeyExchange response")
 
         pos = 0
 
-        keyExchangeVersion = int.from_bytes(data[pos:pos + 4], "little")
+        keyExchangeVersion = int.from_bytes(data[pos : pos + 4], "little")
 
         pos += 4
         log.info(keyExchangeVersion)
 
         if keyExchangeVersion != 2:
-            raise Exception('Unexpected KeyExchange version %', keyExchangeVersion)
+            raise Exception("Unexpected KeyExchange version %", keyExchangeVersion)
 
-        errorCode = int.from_bytes(data[pos: pos + 4], "little")
+        errorCode = int.from_bytes(data[pos : pos + 4], "little")
         pos += 4
 
         if errorCode != 0 and errorCode != 25:
-            raise Exception('received error code % as result of KeyExchange ', errorCode)
+            raise Exception(
+                "received error code % as result of KeyExchange ", errorCode
+            )
 
         if len(data) < (pos + 16 + 16):
-            raise Exception('Insufficient data length in KeyExchange response, have only % bytes ', len(data))
+            raise Exception(
+                "Insufficient data length in KeyExchange response, have only % bytes ",
+                len(data),
+            )
 
-        fD = data[pos: pos + 16]
+        fD = data[pos : pos + 16]
         pos += 16
-        fS = data[pos: pos + 16]
+        fS = data[pos : pos + 16]
         pos += 16
 
         sharedKey = self.generateSharedKey()
@@ -96,47 +102,57 @@ class Crypto():
         authenticatorValid = self.validateAuthenticator(data[pos:], fD, fS, sharedKey)
 
         if authenticatorValid is None:
-            raise Exception('Failed to authenticate key exchange data')
+            raise Exception("Failed to authenticate key exchange data")
 
         fK = self.extractData(data, pos)
-        pos += fK['length']
-        sessionIdentifier = fK['data']
+        pos += fK["length"]
+        sessionIdentifier = fK["data"]
 
         flags = self.extractData(data, pos)
-        pos += flags['length']
+        pos += flags["length"]
 
         if len(data) < (pos + 32):
             raise Exception(
-                'KeyExchange response buffer too short, expected 32 bytes for public key at pos' + pos + ",have length " + len(
-                    data))
+                "KeyExchange response buffer too short, expected 32 bytes for public key at pos"
+                + pos
+                + ",have length "
+                + len(data)
+            )
 
-        publicKey = data[pos:pos + 32]
+        publicKey = data[pos : pos + 32]
 
-        self.cryptoIntermediateData = libnacl.crypto_box_beforenm(publicKey, self.secretKey)
+        self.cryptoIntermediateData = libnacl.crypto_box_beforenm(
+            publicKey, self.secretKey
+        )
 
         return sessionIdentifier
 
     def extractData(self, fX, fY):
         if len(fX) < (fY + 4):
-            raise Exception('Cannot read string from buffer, buffer not large enough')
+            raise Exception("Cannot read string from buffer, buffer not large enough")
 
         fW = fX
-        length = int.from_bytes(fX[fY:(fY + 3)], "little", )
+        length = int.from_bytes(
+            fX[fY : (fY + 3)],
+            "little",
+        )
 
         if length == 0:
-            raise Exception('Failed to read keyId from KeyExchange response')
+            raise Exception("Failed to read keyId from KeyExchange response")
 
         if length > 20000000:
-            raise Exception('Cannot read string from buffer, string length exceeds allowed maximum size')
+            raise Exception(
+                "Cannot read string from buffer, string length exceeds allowed maximum size"
+            )
 
         if length > (len(fX) - fY - 4):
-            raise Exception('Cannot read string from buffer at pos %', fY)
+            raise Exception("Cannot read string from buffer at pos %", fY)
 
-        result = fX[(fY + 4):(fY + 4 + length)]
+        result = fX[(fY + 4) : (fY + 4 + length)]
 
-        result_ascii = result.decode('utf-8')
+        result_ascii = result.decode("utf-8")
 
-        SystemAccessPointResponse = {'data': result_ascii, 'length': 4 + length}
+        SystemAccessPointResponse = {"data": result_ascii, "length": 4 + length}
 
         return SystemAccessPointResponse
 
@@ -156,24 +172,31 @@ class Crypto():
         data_bytes = base64.b64decode(data)
 
         if data_bytes is None or len(data_bytes) == 0:
-            raise Exception('Can not decrypt empty pubsub')
+            raise Exception("Can not decrypt empty pubsub")
 
-        nonce = data_bytes[0:libnacl.crypto_box_NONCEBYTES]
+        nonce = data_bytes[0 : libnacl.crypto_box_NONCEBYTES]
 
         messageReader = MessageReader(data_bytes[16:24])
         nonceNumber = messageReader.readUint64()
-        if 'update' not in self.__Yq:
-            self.__Yq['update'] = {}
-            self.__Yq['update']['sequenceCounter'] = 'cU'  # Was this supposed to be cU (without quotes)?
-            self.__Yq['update']['skippedSymmetricSequences'] = []
+        if "update" not in self.__Yq:
+            self.__Yq["update"] = {}
+            self.__Yq["update"][
+                "sequenceCounter"
+            ] = "cU"  # Was this supposed to be cU (without quotes)?
+            self.__Yq["update"]["skippedSymmetricSequences"] = []
 
-        sequenceNumber = self.__Yq['update']['sequenceCounter']
+        sequenceNumber = self.__Yq["update"]["sequenceCounter"]
         if nonceNumber < sequenceNumber:
-            if nonceNumber not in self.__Yq['update']['skippedSymmetricSequences']:
-                raise Exception('Unexpected sequence in received symmetric nonce ',
-                                nonceNumber, '(', sequenceNumber, ')')
+            if nonceNumber not in self.__Yq["update"]["skippedSymmetricSequences"]:
+                raise Exception(
+                    "Unexpected sequence in received symmetric nonce ",
+                    nonceNumber,
+                    "(",
+                    sequenceNumber,
+                    ")",
+                )
 
-            self.__Yq['update']['skippedSymmetricSequences'].remove(nonceNumber)
+            self.__Yq["update"]["skippedSymmetricSequences"].remove(nonceNumber)
 
         if nonceNumber > sequenceNumber:
             c = nonceNumber - sequenceNumber - 1
@@ -185,21 +208,24 @@ class Crypto():
                 if x == 0:
                     break
 
-            self.__Yq['update']['skippedSymmetricSequences'].append(x)
+            self.__Yq["update"]["skippedSymmetricSequences"].append(x)
             x -= x
 
-            if len(self.__Yq['update']['skippedSymmetricSequences']) > 32:
-                a = sorted(self.__Yq['update']['skippedSymmetricSequences'])  # returns list
+            if len(self.__Yq["update"]["skippedSymmetricSequences"]) > 32:
+                a = sorted(
+                    self.__Yq["update"]["skippedSymmetricSequences"]
+                )  # returns list
                 dK = len(a) - 32
                 for i in range(dK):
-                    self.__Yq['update']['skippedSymmetricSequences'].remove(a[i])
+                    self.__Yq["update"]["skippedSymmetricSequences"].remove(a[i])
 
-        self.__Yq['update']['sequenceCounter'] += 1
+        self.__Yq["update"]["sequenceCounter"] += 1
 
-        pubSubMessage = libnacl.crypto_secretbox_open_easy(data_bytes[libnacl.crypto_box_NONCEBYTES:], nonce,
-                                                           self.__Key)
+        pubSubMessage = libnacl.crypto_secretbox_open_easy(
+            data_bytes[libnacl.crypto_box_NONCEBYTES :], nonce, self.__Key
+        )
         if pubSubMessage is None:
-            raise Exception('Failed to decrypt message')
+            raise Exception("Failed to decrypt message")
 
         return pubSubMessage
 
@@ -211,11 +237,11 @@ class Crypto():
 
         result = data.readUint32()
         if result != Result.RESULT_CODE_OK:
-            raise Exception('Failed to establish session')
+            raise Exception("Failed to establish session")
 
         fah_version = data.readUint32()
         if fah_version != General.PROTOCOL_VERSION:
-            log.info('Unknown Protocol Version detected. Ignoring ...', fah_version)
+            log.info("Unknown Protocol Version detected. Ignoring ...", fah_version)
 
         self.__Ys = data.readString()
         self.__Yt = data.readBlob(8)
@@ -228,14 +254,14 @@ class Crypto():
         cl.writeUint32(0)
 
         if self.messageCounter > 4294967296:
-            raise Exception('MessageCounter exceeds valid range')
+            raise Exception("MessageCounter exceeds valid range")
 
         cl.writeBlob(libnacl.randombytes_buf(8))
         return cl.toUint8Array()
 
     def encryptPayload(self, data):
         if len(data) > 10485760:
-            raise Exception('encryptPayload: message is too large: ', len(data))
+            raise Exception("encryptPayload: message is too large: ", len(data))
 
         cq = 0
         if not self.__Yv:
@@ -244,7 +270,7 @@ class Crypto():
         nonce = self.createNonce()
 
         if nonce is None:
-            raise Exception('MessageCounter exceeds valid range')
+            raise Exception("MessageCounter exceeds valid range")
 
         cn = len(nonce) + General.FH_CRYPTO_MAC_LENGTH + len(data)
         ct = bytearray(libnacl.randombytes_buf(libnacl.crypto_box_NONCEBYTES))
@@ -253,12 +279,14 @@ class Crypto():
         cm += ct
         cm += data
 
-        cr = libnacl.crypto_box_easy_afternm(bytes(cm), bytes(nonce), self.cryptoIntermediateData)
+        cr = libnacl.crypto_box_easy_afternm(
+            bytes(cm), bytes(nonce), self.cryptoIntermediateData
+        )
         if cr is None or len(cr) == 0:
-            raise Exception('Failed to encrypt message')
+            raise Exception("Failed to encrypt message")
 
         if len(cr) != cn:
-            raise Exception('Internal error: Unexpected size of encrypted data array')
+            raise Exception("Internal error: Unexpected size of encrypted data array")
 
         self.__Yp.append(ct)  # append random nonce bytes to list
 
@@ -272,7 +300,7 @@ class Crypto():
 
         return co.toUint8Array()
 
-    def decryptPayload(self, message):  # data is of type messagereader        
+    def decryptPayload(self, message):  # data is of type messagereader
 
         data = MessageReader(message)
 
@@ -283,16 +311,24 @@ class Crypto():
         messageData = data.getRemainingData()
 
         if len(messageData) != messageLength:
-            raise Exception('Failed to decrypt container: invalid message length ', messageLength, ' expected ',
-                            len(messageData))
+            raise Exception(
+                "Failed to decrypt container: invalid message length ",
+                messageLength,
+                " expected ",
+                len(messageData),
+            )
 
         if messageLength < libnacl.crypto_box_MACBYTES:
-            raise Exception('Failed to decrypt container: invalid message length ', messageLength)
+            raise Exception(
+                "Failed to decrypt container: invalid message length ", messageLength
+            )
 
         cX = None
 
         for x in self.__Yp:
-            cX = libnacl.crypto_box_open_easy_afternm(bytes(messageData), bytes(x), self.cryptoIntermediateData)
+            cX = libnacl.crypto_box_open_easy_afternm(
+                bytes(messageData), bytes(x), self.cryptoIntermediateData
+            )
             if cX is not None:
                 self.__Yp.remove(x)
                 break
@@ -305,18 +341,18 @@ class Crypto():
 
             for i in range(numNames):
                 cO = keyData.readString()
-                cL = cO.rfind('/')
+                cL = cO.rfind("/")
                 if cL == -1:
                     continue
 
-                cR = cO[cL + 1:]
-                if cR.endswith('_encrypted'):
-                    cR = cR[0:len(cR) - 10]
+                cR = cO[cL + 1 :]
+                if cR.endswith("_encrypted"):
+                    cR = cR[0 : len(cR) - 10]
 
                 cU = keyData.readUint64()
                 self.__Yq[cR] = {}
-                self.__Yq[cR]['sequenceCounter'] = cU
-                self.__Yq[cR]['skippedSymmetricSequences'] = []
+                self.__Yq[cR]["sequenceCounter"] = cU
+                self.__Yq[cR]["skippedSymmetricSequences"] = []
 
             self.__Yv = True
 
@@ -330,7 +366,9 @@ class Crypto():
         clientFinal = self.clientScramHandler.createClientFinal()
 
         if clientFinal is None or len(clientFinal) == 0:
-            raise Exception('Failed to send login response message, failed to create clientFinal')
+            raise Exception(
+                "Failed to send login response message, failed to create clientFinal"
+            )
 
         return clientFinal
 
@@ -346,7 +384,7 @@ class Crypto():
 def loginSaslPayload(scram):
     messageWriter = MessageWriter()
     messageWriter.writeUint8(FAHMessage.MSG_ID_LOGIN_SASL)
-    messageWriter.writeString('SCRAM-SHA-256')
+    messageWriter.writeString("SCRAM-SHA-256")
     messageWriter.writeString(scram)
     return messageWriter.toUint8Array()
 

--- a/custom_components/freeathome/fah/pure_pynacl/__init__.py
+++ b/custom_components/freeathome/fah/pure_pynacl/__init__.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+import sys
+from array import array
+
+if sys.version_info < (2, 6):
+    raise NotImplementedError("pure_pynacl requires python-2.6 or later")
+
+lt_py3 = sys.version_info < (3,)
+lt_py33 = sys.version_info < (3, 3)
+
+integer = long if lt_py3 else int
+
+
+class TypeEnum(object):
+    """
+    order types used by pure_py(tweet)nacl for rapid type promotion
+    """
+
+    u8 = 1
+    u32 = 2
+    u64 = 3
+    Int = 5
+    i64 = 7
+    integer = 11
+
+
+class Int(integer):
+    """
+    int types
+    """
+
+    bits = array("i").itemsize * 8
+    mask = (1 << bits - 1) - 1
+    signed = True
+    order = TypeEnum.Int
+
+    def __str__(self):
+        return integer.__str__(self)
+
+    def __repr__(self):
+        return "Int(%s)" % integer.__repr__(self)
+
+    def __new__(self, val=0):
+        """
+        ensure that new instances have the correct size and sign
+        """
+        if val < 0:
+            residue = integer(-val) & self.mask
+            if self.signed:
+                residue = -residue
+        else:
+            residue = integer(val) & self.mask
+        return integer.__new__(self, residue)
+
+    def __promote_type(self, other, result):
+        """
+        determine the largest type from those in self and other; if result is
+        negative and both self and other are unsigned, promote it to the least
+        signed type
+        """
+        self_order = self.order
+        other_order = other.order if isinstance(other, Int) else TypeEnum.integer
+
+        if result < 0 and self_order < 5 and other_order < 5:
+            return Int
+        return self.__class__ if self_order > other_order else other.__class__
+
+    def __unary_typed(oper):
+        """
+        return a function that redefines the operation oper such that the
+        result conforms to the type of self
+        """
+
+        def operate(self):
+            """
+            type the result to self
+            """
+            return self.__class__(oper(self))
+
+        return operate
+
+    def __typed(oper):
+        """
+        return a function that redefines the operation oper such that the
+        result conforms to the type of self or other, whichever is larger if
+        both are strongly typed (have a bits attribute); otherwise return the
+        result conforming to the type of self
+        """
+
+        def operate(self, other):
+            """
+            type and bitmask the result to either self or other, whichever is
+            larger
+            """
+            result = oper(self, other)
+            return self.__promote_type(other, result)(result)
+
+        return operate
+
+    def __shift(oper):
+        """
+        return a function that performs bit shifting, but preserves the type of
+        the left value
+        """
+
+        def operate(self, other):
+            """
+            emulate C bit shifting
+            """
+            return self.__class__(oper(self, other))
+
+        return operate
+
+    def __invert():
+        """
+        return a function that performs bit inversion
+        """
+
+        def operate(self):
+            """
+            emulate C bit inversion
+            """
+            if self.signed:
+                return self.__class__(integer.__invert__(self))
+            else:
+                return self.__class__(integer.__xor__(self, self.mask))
+
+        return operate
+
+    # bitwise operations
+    __lshift__ = __shift(integer.__lshift__)
+    __rlshift__ = __shift(integer.__rlshift__)
+    __rshift__ = __shift(integer.__rshift__)
+    __rrshift__ = __shift(integer.__rrshift__)
+    __and__ = __typed(integer.__and__)
+    __rand__ = __typed(integer.__rand__)
+    __or__ = __typed(integer.__or__)
+    __ror__ = __typed(integer.__ror__)
+    __xor__ = __typed(integer.__xor__)
+    __rxor__ = __typed(integer.__rxor__)
+    __invert__ = __invert()
+
+    # arithmetic operations
+    if not lt_py3:
+        __ceil__ = __unary_typed(integer.__ceil__)
+        __floor__ = __unary_typed(integer.__floor__)
+        __int__ = __unary_typed(integer.__int__)
+    __abs__ = __unary_typed(integer.__abs__)
+    __pos__ = __unary_typed(integer.__pos__)
+    __neg__ = __unary_typed(integer.__neg__)
+    __add__ = __typed(integer.__add__)
+    __radd__ = __typed(integer.__radd__)
+    __sub__ = __typed(integer.__sub__)
+    __rsub__ = __typed(integer.__rsub__)
+    __mod__ = __typed(integer.__mod__)
+    __rmod__ = __typed(integer.__rmod__)
+    __mul__ = __typed(integer.__mul__)
+    __rmul__ = __typed(integer.__rmul__)
+    if lt_py3:
+        __div__ = __typed(integer.__div__)
+        __rdiv__ = __typed(integer.__rdiv__)
+    __floordiv__ = __typed(integer.__floordiv__)
+    __rfloordiv__ = __typed(integer.__rfloordiv__)
+    __pow__ = __typed(integer.__pow__)
+    __rpow__ = __typed(integer.__rpow__)
+
+
+class IntArray(list):
+    """
+    arrays of int types
+    """
+
+    def __init__(self, typ, init=(), size=0):
+        """
+        create array of ints
+        """
+        self.typ = typ
+
+        if lt_py3 and isinstance(init, bytes):
+            init = [ord(i) for i in init]
+
+        if size:
+            init_size = len(init)
+            if init_size < size:
+                list.__init__(
+                    self,
+                    [typ(i) for i in init] + [typ() for i in range(size - init_size)],
+                )
+            else:
+                list.__init__(self, [typ(i) for i in init[:size]])
+        else:
+            list.__init__(self, [typ(i) for i in init])
+
+    def __str__(self):
+        return list.__str__(self)
+
+    def __repr__(self):
+        return "IntArray(%s, init=%s)" % (self.typ, list.__repr__(self))
+
+
+# TweetNaCl external functions
+from .tweetnacl import (
+    crypto_verify_16_tweet,
+    crypto_verify_32_tweet,
+    crypto_core_salsa20_tweet,
+    crypto_core_hsalsa20_tweet,
+    crypto_stream_salsa20_tweet_xor,
+    crypto_stream_salsa20_tweet,
+    crypto_stream_xsalsa20_tweet,
+    crypto_stream_xsalsa20_tweet_xor,
+    crypto_onetimeauth_poly1305_tweet,
+    crypto_onetimeauth_poly1305_tweet_verify,
+    crypto_secretbox_xsalsa20poly1305_tweet,
+    crypto_secretbox_xsalsa20poly1305_tweet_open,
+    crypto_scalarmult_curve25519_tweet,
+    crypto_scalarmult_curve25519_tweet_base,
+    crypto_box_curve25519xsalsa20poly1305_tweet_keypair,
+    crypto_box_curve25519xsalsa20poly1305_tweet_beforenm,
+    crypto_box_curve25519xsalsa20poly1305_tweet_afternm,
+    crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm,
+    crypto_box_curve25519xsalsa20poly1305_tweet,
+    crypto_box_curve25519xsalsa20poly1305_tweet_open,
+    crypto_hashblocks_sha512_tweet,
+    crypto_hash_sha512_tweet,
+    crypto_sign_ed25519_tweet_keypair,
+    crypto_sign_ed25519_tweet,
+    crypto_sign_ed25519_tweet_open,
+)

--- a/custom_components/freeathome/fah/pure_pynacl/tweetnacl.py
+++ b/custom_components/freeathome/fah/pure_pynacl/tweetnacl.py
@@ -1,0 +1,1292 @@
+# -*- coding: utf-8 -*-
+
+# import python libs
+import os
+from array import array
+
+# import pure_pynacl libs
+from . import lt_py3, lt_py33
+from . import TypeEnum, integer, Int, IntArray
+
+
+class u8(Int):
+    """unsigned char"""
+
+    bits = array("B").itemsize * 8
+    mask = (1 << bits) - 1
+    signed = False
+    order = TypeEnum.u8
+
+    def __repr__(self):
+        return "u8(%s)" % integer.__repr__(self)
+
+
+class u32(Int):
+    """unsigned long"""
+
+    bits = array("L").itemsize * 8
+    mask = (1 << bits) - 1
+    signed = False
+    order = TypeEnum.u32
+
+    def __repr__(self):
+        return "u32(%s)" % integer.__repr__(self)
+
+
+class u64(Int):
+    """unsigned long long"""
+
+    bits = array("L" if lt_py33 else "Q").itemsize * 8
+    mask = (1 << bits) - 1
+    signed = False
+    order = TypeEnum.u64
+
+    def __repr__(self):
+        return "u64(%s)" % integer.__repr__(self)
+
+
+class i64(Int):
+    """long long"""
+
+    bits = array("l" if lt_py33 else "q").itemsize * 8
+    mask = (1 << bits - 1) - 1
+    signed = True
+    order = TypeEnum.i64
+
+    def __repr__(self):
+        return "i64(%s)" % integer.__repr__(self)
+
+
+class gf(IntArray):
+    def __init__(self, init=()):
+        IntArray.__init__(self, i64, init=init, size=16)
+
+
+def randombytes(c, s):
+    """
+    insert s random bytes into c
+    """
+    if lt_py3:
+        c[:s] = bytearray(os.urandom(s))
+    else:
+        c[:s] = os.urandom(s)
+
+
+_0 = IntArray(u8, size=16)
+_9 = IntArray(u8, size=32, init=[9])
+
+gf0 = gf()
+gf1 = gf([1])
+_121665 = gf([0xDB41, 1])
+D = gf(
+    [
+        0x78A3,
+        0x1359,
+        0x4DCA,
+        0x75EB,
+        0xD8AB,
+        0x4141,
+        0x0A4D,
+        0x0070,
+        0xE898,
+        0x7779,
+        0x4079,
+        0x8CC7,
+        0xFE73,
+        0x2B6F,
+        0x6CEE,
+        0x5203,
+    ]
+)
+D2 = gf(
+    [
+        0xF159,
+        0x26B2,
+        0x9B94,
+        0xEBD6,
+        0xB156,
+        0x8283,
+        0x149A,
+        0x00E0,
+        0xD130,
+        0xEEF3,
+        0x80F2,
+        0x198E,
+        0xFCE7,
+        0x56DF,
+        0xD9DC,
+        0x2406,
+    ]
+)
+X = gf(
+    [
+        0xD51A,
+        0x8F25,
+        0x2D60,
+        0xC956,
+        0xA7B2,
+        0x9525,
+        0xC760,
+        0x692C,
+        0xDC5C,
+        0xFDD6,
+        0xE231,
+        0xC0A4,
+        0x53FE,
+        0xCD6E,
+        0x36D3,
+        0x2169,
+    ]
+)
+Y = gf(
+    [
+        0x6658,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+        0x6666,
+    ]
+)
+I = gf(
+    [
+        0xA0B0,
+        0x4A0E,
+        0x1B27,
+        0xC4EE,
+        0xE478,
+        0xAD2F,
+        0x1806,
+        0x2F43,
+        0xD7A7,
+        0x3DFB,
+        0x0099,
+        0x2B4D,
+        0xDF0B,
+        0x4FC1,
+        0x2480,
+        0x2B83,
+    ]
+)
+
+
+def L32(x, c):
+    """static u32 L32(u32 x, int c)"""
+    return (u32(x) << c) | ((u32(x) & 0xFFFFFFFF) >> (32 - c))
+
+
+def ld32(x):
+    """u32 ld32(const u8*x)"""
+    u = u32(x[3])
+    u = (u << 8) | u32(x[2])
+    u = (u << 8) | u32(x[1])
+    return (u << 8) | u32(x[0])
+
+
+def dl64(x):
+    """u64 dl64(const u8*x)"""
+    u = u64()
+    for i in range(8):
+        u = (u << 8) | u8(x[i])
+    return u
+
+
+def st32(x, u):
+    """void st32(u8*x, u32 u)"""
+    for i in range(4):
+        x[i] = u8(u)
+        u >>= 8
+    return x
+
+
+def ts64(x, u):
+    """void ts64(u8*x, u64 u)"""
+    for i in range(7, -1, -1):
+        x[i] = u8(u)
+        u >>= 8
+    return x
+
+
+def vn(x, y, n):
+    """int vn(const u8*x, const u8*y, int n)"""
+    d = u32()
+    for i in range(n):
+        d |= x[i] ^ y[i]
+    return (1 & ((d - 1) >> 8)) - 1
+
+
+def crypto_verify_16_tweet(x, y):
+    """int crypto_verify_16_tweet(const u8*x, const u8*y)"""
+    return vn(x, y, 16)
+
+
+def crypto_verify_32_tweet(x, y):
+    """int crypto_verify_32_tweet(const u8*x, const u8*y)"""
+    return vn(x, y, 32)
+
+
+def core(out, in_, k, c, h):
+    """void core(u8*out, const u8*in, const u8*k, const u8*c, int h)"""
+    w = IntArray(u32, size=16)
+    x = IntArray(u32, size=16)
+    y = IntArray(u32, size=16)
+    t = IntArray(u32, size=4)
+
+    for i in range(4):
+        x[5 * i] = ld32(c[4 * i :])
+        x[1 + i] = ld32(k[4 * i :])
+        x[6 + i] = ld32(in_[4 * i :])
+        x[11 + i] = ld32(k[16 + 4 * i :])
+
+    for i in range(16):
+        y[i] = x[i]
+
+    for i in range(20):
+        for j in range(4):
+            for m in range(4):
+                t[m] = x[(5 * j + 4 * m) % 16]
+            t[1] ^= L32(t[0] + t[3], 7)
+            t[2] ^= L32(t[1] + t[0], 9)
+            t[3] ^= L32(t[2] + t[1], 13)
+            t[0] ^= L32(t[3] + t[2], 18)
+            for m in range(4):
+                w[4 * j + (j + m) % 4] = t[m]
+        for m in range(16):
+            x[m] = w[m]
+
+    if h:
+        for i in range(16):
+            x[i] += y[i]
+        for i in range(4):
+            x[5 * i] -= ld32(c[4 * i :])
+            x[6 + i] -= ld32(in_[4 * i :])
+        for i in range(4):
+            out[4 * i :] = st32(out[4 * i :], x[5 * i])
+            out[16 + 4 * i :] = st32(out[16 + 4 * i :], x[6 + i])
+    else:
+        for i in range(16):
+            out[4 * i :] = st32(out[4 * i :], x[i] + y[i])
+
+
+def crypto_core_salsa20_tweet(out, in_, k, c):
+    """int crypto_core_salsa20_tweet(u8*out, const u8*in, const u8*k, const u8*c)"""
+    core(out, in_, k, c, False)
+    return 0
+
+
+def crypto_core_hsalsa20_tweet(out, in_, k, c):
+    """int crypto_core_hsalsa20_tweet(u8*out, const u8*in, const u8*k, const u8*c)"""
+    core(out, in_, k, c, True)
+    return 0
+
+
+sigma = IntArray(u8, size=16, init=b"expand 32-byte k")
+
+
+def crypto_stream_salsa20_tweet_xor(c, m, b, n, k):
+    """int crypto_stream_salsa20_tweet_xor(u8*c, const u8*m, u64 b, const u8*n, const u8*k)"""
+    z = IntArray(u8, size=16)
+    x = IntArray(u8, size=64)
+
+    if not b:
+        return 0
+
+    for i in range(8):
+        z[i] = n[i]
+
+    c_off = 0
+    m_off = 0
+    while b >= 64:
+        crypto_core_salsa20_tweet(x, z, k, sigma)
+        for i in range(64):
+            c[i + c_off] = (m[i + m_off] if m else 0) ^ x[i]
+        u = u32(1)
+        for i in range(8, 16):
+            u += u32(z[i])
+            z[i] = u
+            u >>= 8
+        b -= 64
+        c_off += 64
+        if m:
+            m_off += 64
+
+    if b:
+        crypto_core_salsa20_tweet(x, z, k, sigma)
+        for i in range(b):
+            c[i + c_off] = (m[i + m_off] if m else 0) ^ x[i]
+
+    return 0
+
+
+def crypto_stream_salsa20_tweet(c, d, n, k):
+    """int crypto_stream_salsa20_tweet(u8*c, u64 d, const u8*n, const u8*k)"""
+    return crypto_stream_salsa20_tweet_xor(c, IntArray(u8), d, n, k)
+
+
+def crypto_stream_xsalsa20_tweet(c, d, n, k):
+    """int crypto_stream_xsalsa20_tweet(u8*c, u64 d, const u8*n, const u8*k)"""
+    s = IntArray(u8, size=32)
+    crypto_core_hsalsa20_tweet(s, n, k, sigma)
+    return crypto_stream_salsa20_tweet(c, d, n[16:], s)
+
+
+def crypto_stream_xsalsa20_tweet_xor(c, m, d, n, k):
+    """int crypto_stream_xsalsa20_tweet_xor(u8*c, const u8*m, u64 d, const u8*n, const u8*k)"""
+    s = IntArray(u8, size=32)
+    crypto_core_hsalsa20_tweet(s, n, k, sigma)
+    return crypto_stream_salsa20_tweet_xor(c, m, d, n[16:], s)
+
+
+def add1305(h, c):
+    """void add1305(u32*h, const u32*c)"""
+    u = u32()
+    for j in range(17):
+        u += u32(h[j] + c[j])
+        h[j] = u & 255
+        u >>= 8
+
+
+minusp = IntArray(
+    u32, size=17, init=(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 252)
+)
+
+
+def crypto_onetimeauth_poly1305_tweet(out, m, n, k):
+    """int crypto_onetimeauth_poly1305_tweet(u8*out, const u8*m, u64 n, const u8*k)"""
+    s = u32()
+    u = u32()
+    x = IntArray(u32, size=17)
+    r = IntArray(u32, size=17)
+    h = IntArray(u32, size=17)
+    c = IntArray(u32, size=17)
+    g = IntArray(u32, size=17)
+
+    for j in range(16):
+        r[j] = k[j]
+    r[3] &= 15
+    r[4] &= 252
+    r[7] &= 15
+    r[8] &= 252
+    r[11] &= 15
+    r[12] &= 252
+    r[15] &= 15
+
+    while n > 0:
+        c[:17] = 17 * [u32()]
+        for j in range(16):
+            if j >= n:
+                j -= 1
+                break
+            c[j] = m[j]
+        j += 1
+        c[j] = 1
+        m = m[j:]
+        n -= j
+        add1305(h, c)
+
+        for i in range(17):
+            x[i] = 0
+            for j in range(17):
+                x[i] += h[j] * (r[i - j] if j <= i else 320 * r[i + 17 - j])
+
+        for i in range(17):
+            h[i] = x[i]
+        u = 0
+
+        for j in range(16):
+            u += h[j]
+            h[j] = u & 255
+            u >>= 8
+
+        u += h[16]
+        h[16] = u & 3
+        u = 5 * (u >> 2)
+
+        for j in range(16):
+            u += h[j]
+            h[j] = u & 255
+            u >>= 8
+
+        u += h[16]
+        h[16] = u
+
+    for j in range(17):
+        g[j] = h[j]
+    add1305(h, minusp)
+    s = -(h[16] >> 7)
+    for j in range(17):
+        h[j] ^= s & (g[j] ^ h[j])
+
+    for j in range(16):
+        c[j] = k[j + 16]
+    c[16] = 0
+    add1305(h, c)
+    for j in range(16):
+        out[j] = h[j]
+
+    return 0
+
+
+def crypto_onetimeauth_poly1305_tweet_verify(h, m, n, k):
+    """int crypto_onetimeauth_poly1305_tweet_verify(const u8*h, const u8*m, u64 n, const u8*k)"""
+    x = IntArray(u8, size=16)
+    crypto_onetimeauth_poly1305_tweet(x, m, n, k)
+    return crypto_verify_16_tweet(h, x)
+
+
+def crypto_secretbox_xsalsa20poly1305_tweet(c, m, d, n, k):
+    """int crypto_secretbox_xsalsa20poly1305_tweet(u8*c, const u8*m, u64 d, const u8*n, const u8*k)"""
+    if d < 32:
+        return -1
+    crypto_stream_xsalsa20_tweet_xor(c, m, d, n, k)
+    c_out = c[16:]
+    crypto_onetimeauth_poly1305_tweet(c_out, c[32:], d - 32, c)
+    c[16:] = c_out
+    c[:16] = 16 * [u8()]
+    return 0
+
+
+def crypto_secretbox_xsalsa20poly1305_tweet_open(m, c, d, n, k):
+    """int crypto_secretbox_xsalsa20poly1305_tweet_open(u8*m, const u8*c, u64 d, const u8*n, const u8*k)"""
+    x = IntArray(u8, size=32)
+    if d < 32:
+        return -1
+    crypto_stream_xsalsa20_tweet(x, 32, n, k)
+    if crypto_onetimeauth_poly1305_tweet_verify(c[16:], c[32:], d - 32, x) != 0:
+        return -1
+    crypto_stream_xsalsa20_tweet_xor(m, c, d, n, k)
+    m[:32] = 32 * [u8()]
+    return 0
+
+
+def set25519(r, a):
+    """void set25519(gf r, const gf a)"""
+    for i in range(16):
+        r[i] = a[i]
+
+
+def car25519(o):
+    """void car25519(gf o)"""
+    c = i64()
+    for i in range(16):
+        o[i] += i64(1) << 16
+        c = o[i] >> 16
+        o[(i + 1) * (i < 15)] += c - 1 + 37 * (c - 1) * (i == 15)
+        o[i] -= c << 16
+
+
+def sel25519(p, q, b):
+    """void sel25519(gf p, gf q, int b)"""
+    t = i64()
+    c = i64(~(b - 1))
+    for i in range(16):
+        t = c & (p[i] ^ q[i])
+        p[i] ^= t
+        q[i] ^= t
+    return p, q
+
+
+def pack25519(o, n):
+    """void pack25519(u8*o, const gf n)"""
+    b = int()
+    m = gf()
+    t = gf()
+    for i in range(16):
+        t[i] = n[i]
+
+    car25519(t)
+    car25519(t)
+    car25519(t)
+
+    for j in range(2):
+        m[0] = t[0] - 0xFFED
+        for i in range(1, 15):
+            m[i] = t[i] - 0xFFFF - ((m[i - 1] >> 16) & 1)
+            m[i - 1] &= 0xFFFF
+
+        m[15] = t[15] - 0x7FFF - ((m[14] >> 16) & 1)
+        b = (m[15] >> 16) & 1
+        m[14] &= 0xFFFF
+
+        sel25519(t, m, 1 - b)
+
+    for i in range(16):
+        o[2 * i] = t[i] & 0xFF
+        o[2 * i + 1] = t[i] >> 8
+
+
+def neq25519(a, b):
+    """int neq25519(const gf a, const gf b)"""
+    c = IntArray(u8, size=32)
+    d = IntArray(u8, size=32)
+    pack25519(c, a)
+    pack25519(d, b)
+    return crypto_verify_32_tweet(c, d)
+
+
+def par25519(a):
+    """u8 par25519(const gf a)"""
+    d = IntArray(u8, size=32)
+    pack25519(d, a)
+    return d[0] & 1
+
+
+def unpack25519(o, n):
+    """void unpack25519(gf o, const u8*n)"""
+    for i in range(16):
+        o[i] = n[2 * i] + (i64(n[2 * i + 1]) << 8)
+    o[15] &= 0x7FFF
+
+
+def A(o, a, b):
+    """void A(gf o, const gf a, const gf b)"""
+    for i in range(16):
+        o[i] = a[i] + b[i]
+
+
+def Z(o, a, b):
+    """void Z(gf o, const gf a, const gf b)"""
+    for i in range(16):
+        o[i] = a[i] - b[i]
+
+
+def M(o, a, b):
+    """void M(gf o, const gf a, const gf b)"""
+    t = IntArray(i64, size=31)
+    for i in range(16):
+        for j in range(16):
+            t[i + j] += a[i] * b[j]
+    for i in range(15):
+        t[i] += 38 * t[i + 16]
+    for i in range(16):
+        o[i] = t[i]
+
+    car25519(o)
+    car25519(o)
+
+    return o
+
+
+def S(o, a):
+    """void S(gf o, const gf a)"""
+    M(o, a, a)
+
+
+def inv25519(o, i):
+    """void inv25519(gf o, const gf i)"""
+    c = gf()
+    for a in range(16):
+        c[a] = i[a]
+    for a in range(253, -1, -1):
+        S(c, c)
+        if a != 2 and a != 4:
+            M(c, c, i)
+
+    for a in range(16):
+        o[a] = c[a]
+
+    return o
+
+
+def pow2523(o, i):
+    """void pow2523(gf o, const gf i)"""
+    c = gf()
+    for a in range(16):
+        c[a] = i[a]
+    for a in range(250, -1, -1):
+        S(c, c)
+        if a != 1:
+            M(c, c, i)
+
+    for a in range(16):
+        o[a] = c[a]
+
+
+def crypto_scalarmult_curve25519_tweet(q, n, p):
+    """int crypto_scalarmult_curve25519_tweet(u8*q, const u8*n, const u8*p)"""
+    z = IntArray(u8, size=32)
+    x = IntArray(i64, size=80)
+    r = i64()
+
+    a = gf()
+    b = gf()
+    c = gf()
+    d = gf()
+    e = gf()
+    f = gf()
+
+    for i in range(31):
+        z[i] = n[i]
+    z[31] = (n[31] & 127) | 64
+    z[0] &= 248
+
+    unpack25519(x, p)
+
+    for i in range(16):
+        b[i] = x[i]
+        d[i] = a[i] = c[i] = 0
+
+    a[0] = d[0] = 1
+    for i in range(254, -1, -1):
+        r = (z[i >> 3] >> (i & 7)) & 1
+        sel25519(a, b, r)
+        sel25519(c, d, r)
+        A(e, a, c)
+        Z(a, a, c)
+        A(c, b, d)
+        Z(b, b, d)
+        S(d, e)
+        S(f, a)
+        M(a, c, a)
+        M(c, b, e)
+        A(e, a, c)
+        Z(a, a, c)
+        S(b, a)
+        Z(c, d, f)
+        M(a, c, _121665)
+        A(a, a, d)
+        M(c, c, a)
+        M(a, d, f)
+        M(d, b, x)
+        S(b, e)
+        sel25519(a, b, r)
+        sel25519(c, d, r)
+
+    for i in range(16):
+        x[i + 16] = a[i]
+        x[i + 32] = c[i]
+        x[i + 48] = b[i]
+        x[i + 64] = d[i]
+
+    x[32:] = inv25519(x[32:], x[32:])
+    x[16:] = M(x[16:], x[16:], x[32:])
+    pack25519(q, x[16:])
+    return 0
+
+
+def crypto_scalarmult_curve25519_tweet_base(q, n):
+    """int crypto_scalarmult_curve25519_tweet_base(u8*q, const u8*n)"""
+    return crypto_scalarmult_curve25519_tweet(q, n, _9)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet_keypair(y, x):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet_keypair(u8*y, u8*x)"""
+    randombytes(x, 32)
+    return crypto_scalarmult_curve25519_tweet_base(y, x)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(k, y, x):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(u8*k, const u8*y, const u8*x)"""
+    s = IntArray(u8, size=32)
+    crypto_scalarmult_curve25519_tweet(s, x, y)
+    return crypto_core_hsalsa20_tweet(k, _0, s, sigma)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet_afternm(c, m, d, n, k):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet_afternm(u8*c, const u8*m, u64 d, const u8*n, const u8*k)"""
+    return crypto_secretbox_xsalsa20poly1305_tweet(c, m, d, n, k)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm(m, c, d, n, k):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm(u8*m, const u8*c, u64 d, const u8*n, const u8*k)"""
+    return crypto_secretbox_xsalsa20poly1305_tweet_open(m, c, d, n, k)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet(c, m, d, n, y, x):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet(u8*c, const u8*m, u64 d, const u8*n, const u8*y, const u8*x)"""
+    k = IntArray(u8, size=32)
+    crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(k, y, x)
+    return crypto_box_curve25519xsalsa20poly1305_tweet_afternm(c, m, d, n, k)
+
+
+def crypto_box_curve25519xsalsa20poly1305_tweet_open(m, c, d, n, y, x):
+    """int crypto_box_curve25519xsalsa20poly1305_tweet_open(u8*m, const u8*c, u64 d, const u8*n, const u8*y, const u8*x)"""
+    k = IntArray(u8, size=32)
+    crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(k, y, x)
+    return crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm(m, c, d, n, k)
+
+
+def R(x, c):
+    """u64 R(u64 x, int c)"""
+    return (u64(x) >> c) | (u64(x) << (64 - c))
+
+
+def Ch(x, y, z):
+    """u64 Ch(u64 x, u64 y, u64 z)"""
+    return (u64(x) & u64(y)) ^ (~u64(x) & u64(z))
+
+
+def Maj(x, y, z):
+    """u64 Maj(u64 x, u64 y, u64 z)"""
+    return (u64(x) & u64(y)) ^ (u64(x) & u64(z)) ^ (u64(y) & u64(z))
+
+
+def Sigma0(x):
+    """u64 Sigma0(u64 x)"""
+    return R(x, 28) ^ R(x, 34) ^ R(x, 39)
+
+
+def Sigma1(x):
+    """u64 Sigma1(u64 x)"""
+    return R(x, 14) ^ R(x, 18) ^ R(x, 41)
+
+
+def sigma0(x):
+    """u64 sigma0(u64 x)"""
+    return R(x, 1) ^ R(x, 8) ^ (x >> 7)
+
+
+def sigma1(x):
+    """u64 sigma1(u64 x)"""
+    return R(x, 19) ^ R(x, 61) ^ (x >> 6)
+
+
+K = IntArray(
+    u64,
+    size=80,
+    init=[
+        0x428A2F98D728AE22,
+        0x7137449123EF65CD,
+        0xB5C0FBCFEC4D3B2F,
+        0xE9B5DBA58189DBBC,
+        0x3956C25BF348B538,
+        0x59F111F1B605D019,
+        0x923F82A4AF194F9B,
+        0xAB1C5ED5DA6D8118,
+        0xD807AA98A3030242,
+        0x12835B0145706FBE,
+        0x243185BE4EE4B28C,
+        0x550C7DC3D5FFB4E2,
+        0x72BE5D74F27B896F,
+        0x80DEB1FE3B1696B1,
+        0x9BDC06A725C71235,
+        0xC19BF174CF692694,
+        0xE49B69C19EF14AD2,
+        0xEFBE4786384F25E3,
+        0x0FC19DC68B8CD5B5,
+        0x240CA1CC77AC9C65,
+        0x2DE92C6F592B0275,
+        0x4A7484AA6EA6E483,
+        0x5CB0A9DCBD41FBD4,
+        0x76F988DA831153B5,
+        0x983E5152EE66DFAB,
+        0xA831C66D2DB43210,
+        0xB00327C898FB213F,
+        0xBF597FC7BEEF0EE4,
+        0xC6E00BF33DA88FC2,
+        0xD5A79147930AA725,
+        0x06CA6351E003826F,
+        0x142929670A0E6E70,
+        0x27B70A8546D22FFC,
+        0x2E1B21385C26C926,
+        0x4D2C6DFC5AC42AED,
+        0x53380D139D95B3DF,
+        0x650A73548BAF63DE,
+        0x766A0ABB3C77B2A8,
+        0x81C2C92E47EDAEE6,
+        0x92722C851482353B,
+        0xA2BFE8A14CF10364,
+        0xA81A664BBC423001,
+        0xC24B8B70D0F89791,
+        0xC76C51A30654BE30,
+        0xD192E819D6EF5218,
+        0xD69906245565A910,
+        0xF40E35855771202A,
+        0x106AA07032BBD1B8,
+        0x19A4C116B8D2D0C8,
+        0x1E376C085141AB53,
+        0x2748774CDF8EEB99,
+        0x34B0BCB5E19B48A8,
+        0x391C0CB3C5C95A63,
+        0x4ED8AA4AE3418ACB,
+        0x5B9CCA4F7763E373,
+        0x682E6FF3D6B2B8A3,
+        0x748F82EE5DEFB2FC,
+        0x78A5636F43172F60,
+        0x84C87814A1F0AB72,
+        0x8CC702081A6439EC,
+        0x90BEFFFA23631E28,
+        0xA4506CEBDE82BDE9,
+        0xBEF9A3F7B2C67915,
+        0xC67178F2E372532B,
+        0xCA273ECEEA26619C,
+        0xD186B8C721C0C207,
+        0xEADA7DD6CDE0EB1E,
+        0xF57D4F7FEE6ED178,
+        0x06F067AA72176FBA,
+        0x0A637DC5A2C898A6,
+        0x113F9804BEF90DAE,
+        0x1B710B35131C471B,
+        0x28DB77F523047D84,
+        0x32CAAB7B40C72493,
+        0x3C9EBE0A15C9BEBC,
+        0x431D67C49C100D4C,
+        0x4CC5D4BECB3E42B6,
+        0x597F299CFC657E2A,
+        0x5FCB6FAB3AD6FAEC,
+        0x6C44198C4A475817,
+    ],
+)
+
+
+def crypto_hashblocks_sha512_tweet(x, m, n):
+    """int crypto_hashblocks_sha512_tweet(u8*x, const u8*m, u64 n)"""
+    z = IntArray(u64, size=8)
+    b = IntArray(u64, size=8)
+    a = IntArray(u64, size=8)
+    w = IntArray(u64, size=16)
+    t = u64()
+
+    for i in range(8):
+        z[i] = a[i] = dl64(x[8 * i :])
+
+    m_off = 0
+    while n >= 128:
+        for i in range(16):
+            w[i] = dl64(m[8 * i + m_off :])
+
+        for i in range(80):
+            for j in range(8):
+                b[j] = a[j]
+            t = a[7] + Sigma1(a[4]) + Ch(a[4], a[5], a[6]) + K[i] + w[i % 16]
+            b[7] = t + Sigma0(a[0]) + Maj(a[0], a[1], a[2])
+            b[3] += t
+
+            for j in range(8):
+                a[(j + 1) % 8] = b[j]
+            if i % 16 == 15:
+                for j in range(16):
+                    w[j] += (
+                        w[(j + 9) % 16]
+                        + sigma0(w[(j + 1) % 16])
+                        + sigma1(w[(j + 14) % 16])
+                    )
+
+        for i in range(8):
+            a[i] += z[i]
+            z[i] = a[i]
+
+        m_off += 128
+        n -= 128
+
+    for i in range(8):
+        x[8 * i :] = ts64(x[8 * i :], z[i])
+
+    return n
+
+
+iv = IntArray(
+    u8,
+    size=64,
+    init=[
+        0x6A,
+        0x09,
+        0xE6,
+        0x67,
+        0xF3,
+        0xBC,
+        0xC9,
+        0x08,
+        0xBB,
+        0x67,
+        0xAE,
+        0x85,
+        0x84,
+        0xCA,
+        0xA7,
+        0x3B,
+        0x3C,
+        0x6E,
+        0xF3,
+        0x72,
+        0xFE,
+        0x94,
+        0xF8,
+        0x2B,
+        0xA5,
+        0x4F,
+        0xF5,
+        0x3A,
+        0x5F,
+        0x1D,
+        0x36,
+        0xF1,
+        0x51,
+        0x0E,
+        0x52,
+        0x7F,
+        0xAD,
+        0xE6,
+        0x82,
+        0xD1,
+        0x9B,
+        0x05,
+        0x68,
+        0x8C,
+        0x2B,
+        0x3E,
+        0x6C,
+        0x1F,
+        0x1F,
+        0x83,
+        0xD9,
+        0xAB,
+        0xFB,
+        0x41,
+        0xBD,
+        0x6B,
+        0x5B,
+        0xE0,
+        0xCD,
+        0x19,
+        0x13,
+        0x7E,
+        0x21,
+        0x79,
+    ],
+)
+
+
+def crypto_hash_sha512_tweet(out, m, n):
+    """int crypto_hash_sha512_tweet(u8*out, const u8*m, u64 n)"""
+    h = IntArray(u8, size=64)
+    x = IntArray(u8, size=256)
+    b = u64(n)
+
+    for i in range(64):
+        h[i] = iv[i]
+
+    crypto_hashblocks_sha512_tweet(h, m, n)
+    m_off = n
+    n &= 127
+    m_off -= n
+
+    x[:256] = 256 * [u8()]
+    for i in range(n):
+        x[i] = m[i + m_off]
+    x[n] = 128
+
+    n = 256 - 128 * (n < 112)
+    x[n - 9] = b >> 61
+    x[n - 8 :] = ts64(x[n - 8 :], b << 3)
+    crypto_hashblocks_sha512_tweet(h, x, n)
+
+    for i in range(64):
+        out[i] = h[i]
+
+    return 0
+
+
+def add(p, q):
+    """void add(gf p[4], gf q[4])"""
+    a = gf()
+    b = gf()
+    c = gf()
+    d = gf()
+    t = gf()
+    e = gf()
+    f = gf()
+    g = gf()
+    h = gf()
+
+    Z(a, p[1], p[0])
+    Z(t, q[1], q[0])
+    M(a, a, t)
+    A(b, p[0], p[1])
+    A(t, q[0], q[1])
+    M(b, b, t)
+    M(c, p[3], q[3])
+    M(c, c, D2)
+    M(d, p[2], q[2])
+    A(d, d, d)
+    Z(e, b, a)
+    Z(f, d, c)
+    A(g, d, c)
+    A(h, b, a)
+
+    M(p[0], e, f)
+    M(p[1], h, g)
+    M(p[2], g, f)
+    M(p[3], e, h)
+
+
+def cswap(p, q, b):
+    """void cswap(gf p[4], gf q[4], u8 b)"""
+    for i in range(4):
+        p[i], q[i] = sel25519(p[i], q[i], b)
+
+
+def pack(r, p):
+    """void pack(u8*r, gf p[4])"""
+    tx = gf()
+    ty = gf()
+    zi = gf()
+    inv25519(zi, p[2])
+    M(tx, p[0], zi)
+    M(ty, p[1], zi)
+    pack25519(r, ty)
+    r[31] ^= par25519(tx) << 7
+
+
+def scalarmult(p, q, s):
+    """void scalarmult(gf p[4], gf q[4], const u8*s)"""
+    set25519(p[0], gf0)
+    set25519(p[1], gf1)
+    set25519(p[2], gf1)
+    set25519(p[3], gf0)
+    for i in range(255, -1, -1):
+        b = u8((s[i // 8] >> (i & 7)) & 1)
+        cswap(p, q, b)
+        add(q, p)
+        add(p, p)
+        cswap(p, q, b)
+
+
+def scalarbase(p, s):
+    """void scalarbase(gf p[4], const u8*s)"""
+    q = [gf() for i in range(4)]
+    set25519(q[0], X)
+    set25519(q[1], Y)
+    set25519(q[2], gf1)
+    M(q[3], X, Y)
+    scalarmult(p, q, s)
+
+
+def crypto_sign_ed25519_tweet_keypair(pk, sk):
+    """int crypto_sign_ed25519_tweet_keypair(u8*pk, u8*sk)"""
+    d = IntArray(u8, size=64)
+    p = [gf() for i in range(4)]
+
+    randombytes(sk, 32)
+    crypto_hash_sha512_tweet(d, sk, 32)
+    d[0] &= 248
+    d[31] &= 127
+    d[31] |= 64
+
+    scalarbase(p, d)
+    pack(pk, p)
+
+    for i in range(32):
+        sk[32 + i] = pk[i]
+    return 0
+
+
+L = IntArray(
+    u64,
+    size=32,
+    init=[
+        0xED,
+        0xD3,
+        0xF5,
+        0x5C,
+        0x1A,
+        0x63,
+        0x12,
+        0x58,
+        0xD6,
+        0x9C,
+        0xF7,
+        0xA2,
+        0xDE,
+        0xF9,
+        0xDE,
+        0x14,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x10,
+    ],
+)
+
+
+def modL(r, x):
+    """void modL(u8*r, i64 x[64])"""
+    carry = i64()
+    for i in range(63, 31, -1):
+        carry = 0
+        for j in range(i - 32, i - 12):
+            x[j] += carry - 16 * x[i] * L[j - (i - 32)]
+            carry = (x[j] + 128) >> 8
+            x[j] -= carry << 8
+        j += 1
+        x[j] += carry
+        x[i] = 0
+
+    carry = 0
+    for j in range(32):
+        x[j] += carry - (x[31] >> 4) * L[j]
+        carry = x[j] >> 8
+        x[j] &= 255
+
+    for j in range(32):
+        x[j] -= carry * L[j]
+    for i in range(32):
+        x[i + 1] += x[i] >> 8
+        r[i] = x[i] & 255
+
+    return r
+
+
+def reduce(r):
+    """void reduce(u8*r)"""
+    x = IntArray(i64, size=64)
+    for i in range(64):
+        x[i] = u64(r[i])
+    r[:64] = 64 * [u8()]
+    modL(r, x)
+
+
+def crypto_sign_ed25519_tweet(sm, smlen, m, n, sk):
+    """int crypto_sign_ed25519_tweet(u8*sm, u64*smlen, const u8*m, u64 n, const u8*sk)"""
+    d = IntArray(u8, size=64)
+    h = IntArray(u8, size=64)
+    r = IntArray(u8, size=64)
+    x = IntArray(i64, size=64)
+    p = [gf() for i in range(4)]
+
+    crypto_hash_sha512_tweet(d, sk, 32)
+    d[0] &= 248
+    d[31] &= 127
+    d[31] |= 64
+
+    # There is no (simple?) way to return this argument's value back to the
+    # user in python.  Rather than redefining the return value of this function
+    # it is better to advise the user that ``smlen`` does not work as it does
+    # in the C implementation and that its value will be equal to ``n + 64``.
+    smlen = n + 64
+    for i in range(n):
+        sm[64 + i] = m[i]
+    for i in range(32):
+        sm[32 + i] = d[32 + i]
+
+    crypto_hash_sha512_tweet(r, sm[32:], n + 32)
+    reduce(r)
+    scalarbase(p, r)
+    pack(sm, p)
+
+    for i in range(32):
+        sm[i + 32] = sk[i + 32]
+    crypto_hash_sha512_tweet(h, sm, n + 64)
+    reduce(h)
+
+    for i in range(64):
+        x[i] = 0
+    for i in range(32):
+        x[i] = u64(r[i])
+    for i in range(32):
+        for j in range(32):
+            x[i + j] += h[i] * u64(d[j])
+    sm[32:] = modL(sm[32:], x)
+
+    return 0
+
+
+def unpackneg(r, p):
+    """int unpackneg(gf r[4], const u8 p[32])"""
+    t = gf()
+    chk = gf()
+    num = gf()
+    den = gf()
+    den2 = gf()
+    den4 = gf()
+    den6 = gf()
+
+    set25519(r[2], gf1)
+    unpack25519(r[1], p)
+    S(num, r[1])
+    M(den, num, D)
+    Z(num, num, r[2])
+    A(den, r[2], den)
+
+    S(den2, den)
+    S(den4, den2)
+    M(den6, den4, den2)
+    M(t, den6, num)
+    M(t, t, den)
+
+    pow2523(t, t)
+    M(t, t, num)
+    M(t, t, den)
+    M(t, t, den)
+    M(r[0], t, den)
+
+    S(chk, r[0])
+    M(chk, chk, den)
+    if neq25519(chk, num):
+        M(r[0], r[0], I)
+
+    S(chk, r[0])
+    M(chk, chk, den)
+    if neq25519(chk, num):
+        return -1
+
+    if par25519(r[0]) == (p[31] >> 7):
+        Z(r[0], gf0, r[0])
+
+    M(r[3], r[0], r[1])
+    return 0
+
+
+def crypto_sign_ed25519_tweet_open(m, mlen, sm, n, pk):
+    """int crypto_sign_ed25519_tweet_open(u8*m, u64*mlen, const u8*sm, u64 n, const u8*pk)"""
+    t = IntArray(u8, size=32)
+    h = IntArray(u8, size=64)
+    p = [gf() for i in range(4)]
+    q = [gf() for i in range(4)]
+
+    mlen = -1
+    if n < 64:
+        return -1
+
+    if unpackneg(q, pk):
+        return -1
+
+    for i in range(n):
+        m[i] = sm[i]
+    for i in range(32):
+        m[i + 32] = pk[i]
+    crypto_hash_sha512_tweet(h, m, n)
+    reduce(h)
+    scalarmult(p, q, h)
+
+    scalarbase(q, sm[32:])
+    add(p, q)
+    pack(t, p)
+
+    n -= 64
+    if crypto_verify_32_tweet(sm, t):
+        for i in range(n):
+            m[i] = 0
+        return -1
+
+    for i in range(n):
+        m[i] = sm[i + 64]
+    # There is no (simple?) way to return this argument's value back to the
+    # user in python.  Rather than redefining the return value of this function
+    # it is better to advise the user that ``mlen`` does not work as it does in
+    # the C implementation and that its value will be equal to ``-1`` if ``n <
+    # 64`` or decryption fails and ``n - 64`` otherwise.
+    mlen = n
+    return 0

--- a/custom_components/freeathome/manifest.json
+++ b/custom_components/freeathome/manifest.json
@@ -6,7 +6,7 @@
   "config_flow": true,
   "dependencies": [],
   "codeowners": ["@jheling"],
-  "requirements": ["slixmpp==1.8.2", "libnacl==1.7.0"],
+  "requirements": ["slixmpp==1.8.2", "pynacl==1.5.0"],
   "iot_class": "local_push",
   "zeroconf": ["_http._tcp.local."]
 }

--- a/custom_components/freeathome/requirements.txt
+++ b/custom_components/freeathome/requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.1.1
 pytest-asyncio==0.14.0
-slixmpp==1.5.1
-libnacl==1.7.0
+slixmpp==1.8.2
+pynacl==1.5.0


### PR DESCRIPTION
Since libsodium is no longer included in the OS build of Home Assistant the libnacl library does no longer work out of the box.

With this PR the libnacl library is replaced by pynacl. Since not all functions used by the free@home integration are available in pynacl I have used two functions from the pure_pynacl library.

I have tested this change on HA 2022.8.4 Docker image on a Raspberry Pi.

Since I developed on a development image of Home Assistant, the code style is changed to Black as well for the applicable python files.

Closes #130 