### PR TITLE
Fix clicking relays when turning off lights that are already off

### DIFF
--- a/custom_components/freeathome/fah/devices/fah_light.py
+++ b/custom_components/freeathome/fah/devices/fah_light.py
@@ -45,8 +45,9 @@ class FahLight(FahDevice):
     async def turn_on(self):
         """ Turn the light on   """
         oldstate = self.state
-        await self.client.set_datapoint(self.serialnumber, self.channel_id, self._datapoints[PID_SWITCH_ON_OFF], '1')
-        self.state = True
+        if self.state == False:
+            await self.client.set_datapoint(self.serialnumber, self.channel_id, self._datapoints[PID_SWITCH_ON_OFF], '1')
+            self.state = True
 
         if self.is_dimmer() \
                 and ((oldstate != self.state and int(self.brightness) > 0) or (oldstate == self.state)):
@@ -54,8 +55,9 @@ class FahLight(FahDevice):
 
     async def turn_off(self):
         """ Turn the light off   """
-        await self.client.set_datapoint(self.serialnumber, self.channel_id, self._datapoints[PID_SWITCH_ON_OFF], '0')
-        self.state = False
+        if self.state == True:
+            await self.client.set_datapoint(self.serialnumber, self.channel_id, self._datapoints[PID_SWITCH_ON_OFF], '0')
+            self.state = False
 
     def set_brightness(self, brightness):
         """ Set the brightness of the light  """


### PR DESCRIPTION
I have a scene that turns off all lights at night. I noticed that the in-wall relays click when I turn on this scene, even if the light has already been off. This will probably reduce the lifetime of the relays. 

I fixed this by respecting the state monitored by the component, and only sending a turn on/off signal if the device is not yet on/off. Working good so far over the last months.