### PR TITLE
Adjust `getAll` command to be less verbose.

### DIFF
--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -625,7 +625,7 @@ class Client(slixmpp.ClientXMPP):
     async def get_config(self, pretty=False):
         """Get config file via getAll RPC"""
         pretty_value = 1 if pretty else 0
-        my_iq = await self.send_rpc_iq('RemoteInterface.getAll', 'de', 2, pretty_value, 0)
+        my_iq = await self.send_rpc_iq('RemoteInterface.getAll', 'de', 1, pretty_value, 0)
         my_iq.enable('rpc_query')
 
         if my_iq['rpc_query']['method_response']['fault'] is not None:


### PR DESCRIPTION
That addresses https://github.com/jheling/freeathome/issues/190.

Passing in `2` provices a much more verbose/debug output which include duplicate property names in SysAP 3.3.1.

I'm unable to find any public documentation on how this interface works so it's tough for me to confirm. Local testing on my SysAP seems to work without issues. I'm running SysAP `3.2.3`.

I tested both and `2` is definitely much more verbose. For my config `1` produces 19551 lines, and `2` produces  37350 lines. Nearly doubling the size.

```
2024-07-09 09:15:41.882 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry 192.168.178.165 for freeathome
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 504, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/freeathome/__init__.py", line 84, in async_setup_entry
    await sysap.find_devices()
  File "/config/custom_components/freeathome/fah/pfreeathome.py", line 954, in find_devices
    await self.xmpp.find_devices(self._use_room_names, self._switch_as_x)
  File "/config/custom_components/freeathome/fah/pfreeathome.py", line 661, in find_devices
    root = ET.fromstring(config_without_names)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/xml/etree/ElementTree.py", line 1330, in XML
    parser.feed(text)
xml.etree.ElementTree.ParseError: duplicate attribute: line 1, column 8918724
```