### PR TITLE
Bugfix: Remove inputPairingId and outputPairingId attributes

### DIFF
--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -564,7 +564,9 @@ class Client(slixmpp.ClientXMPP):
         # Strip them altogether.
         xml_without_names = re.sub(r'name="[^"]*" ([^>]*)name="[^"]*"', r'\1', xml)
         xml_without_imaginary = re.sub(r'imaginary="[^"]*" ([^>]*)imaginary="[^"]*"', r'\1', xml_without_names)
-        return xml_without_imaginary
+        xml_without_inputPairingId = re.sub(r'inputPairingId="[^"]*" ([^>]*)inputPairingId="[^"]*"', r'\1', xml_without_imaginary)
+        xml_without_outputPairingId = re.sub(r'outputPairingId="[^"]*" ([^>]*)outputPairingId="[^"]*"', r'\1', xml_without_inputPairingId)
+        return xml_without_outputPairingId
 
     def add_update_handler(self, handler):
         """Add update handler"""

--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -562,11 +562,12 @@ class Client(slixmpp.ClientXMPP):
     def clean_xml(self, xml):
         # Ugly hack: Some SysAPs seem to return invalid XML, i.e. duplicate name attributes
         # Strip them altogether.
-        xml_without_names = re.sub(r'name="[^"]*" ([^>]*)name="[^"]*"', r'\1', xml)
-        xml_without_imaginary = re.sub(r'imaginary="[^"]*" ([^>]*)imaginary="[^"]*"', r'\1', xml_without_names)
-        xml_without_inputPairingId = re.sub(r'inputPairingId="[^"]*" ([^>]*)inputPairingId="[^"]*"', r'\1', xml_without_imaginary)
-        xml_without_outputPairingId = re.sub(r'outputPairingId="[^"]*" ([^>]*)outputPairingId="[^"]*"', r'\1', xml_without_inputPairingId)
-        return xml_without_outputPairingId
+        duplicates = ["name", "imaginary", "inputPairingId", "outputPairingId"]
+
+        for duplicate in duplicates:
+            xml = re.sub(rf"{duplicate}=\"[^\"]*\" ([^>]*){duplicate}=\"[^\"]*\"", r'\1', xml)
+
+        return xml
 
     def add_update_handler(self, handler):
         """Add update handler"""


### PR DESCRIPTION
Bugfix for #190 @jheling 
Since firmware 3.3.1 the config xml may contain such a row:
`<parameter dpt="0705" dependencyIndex="FFFF" sync="none" matchCode="00000001" parameterId="0015" nameId="016D" outputPairingId="01AF" writable="true" inputPairingId="01AE" applyScope="none" visible="true" accessLevel="Enduser" name="Autonomous switch off time duration" i="pm0000" optional="false" inputPairingId="01AE" outputPairingId="01AF">`

The attributes inputPairingId and outputPairingId are each time dublicated, which causes an exception while parsing the XML tree. This is again a somehow ugly regex filtering before processing the xml. Other ideas are apprecicated to fix this. I'm also wondering, why this problem happens. @oliverlinsenmaier provided me two xml samples
1. Fetched from the original backup feature of the sysAp
2. Fetched from this component, bypassed and exported

While 1. is a valid xml, 2. contains this error. 

Anyway, this fix should work fine....till new attributes are incoming 😄 