### PR TITLE
Replace deprecated ZeroconfServiceInfo import

### DIFF
--- a/custom_components/freeathome/config_flow.py
+++ b/custom_components/freeathome/config_flow.py
@@ -7,7 +7,7 @@ from ipaddress import IPv4Address
 
 import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
-from homeassistant.components import zeroconf
+from homeassistant.helpers.service_info import zeroconf
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,


### PR DESCRIPTION
fixes #238 by replacing the deprecated import to the new one. Not urgent, as the deprecation hits in 2026, but good to be early with this easy fix.

I tested the config flow by setting up my integration from start. HA immediately detected the fah installation via ZeroConf, so it looks like it works.