### PR TITLE
Relax pynacl dependency constraints to fix HA 2026.1.2 conflict

### DIFF
--- a/custom_components/freeathome/manifest.json
+++ b/custom_components/freeathome/manifest.json
@@ -10,7 +10,7 @@
   ],
   "requirements": [
     "slixmpp==1.10.0",
-    "pynacl==1.6.0"
+    "pynacl>=1.6.0"
   ],
   "iot_class": "local_push",
   "zeroconf": [

--- a/custom_components/freeathome/requirements.txt
+++ b/custom_components/freeathome/requirements.txt
@@ -1,4 +1,4 @@
 pytest==6.1.1
 pytest-asyncio==0.14.0
 slixmpp==1.10.0
-pynacl==1.6.0
+pynacl>=1.6.0


### PR DESCRIPTION
Replaced strict version pinning (==) with a minimum version requirement (>=) for pynacl in manifest.json and requirements.txt. 

The hardcoded version was causing dependency errors after updating to Home Assistant 2026.1.2, as HA Core now uses a newer version of the library. This change allows the component to use the installed system version.