### PR TITLE
Add missing device name '08A7' and make device name lookup resilient

### DIFF
--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -749,7 +749,7 @@ class Client(slixmpp.ClientXMPP):
                 device_display_name = get_attribute(device, 'displayName')
                 device_floor_id = get_attribute(device, 'floor')
                 device_room_id = get_attribute(device, 'room')
-                device_model = names[device_name_id]
+                device_model = names.get(device_name_id, 'Unknown device ' + device_name_id)
 
                 device_name = device_display_name if device_display_name != '' else device_model
                 device_name = device_name + " (" + device_serialnumber + ")"

--- a/custom_components/freeathome/names.json
+++ b/custom_components/freeathome/names.json
@@ -9907,6 +9907,10 @@
     {
       "nameId": "001E",
       "string": "Aktuelle absolute Jalousieposition in %"
+    },
+    {
+      "nameId": "08A7",
+      "string": "Schaltaktor 2-fach wireless"
     }
   ]
 }


### PR DESCRIPTION
Fixes #284

## Summary

This PR fixes a `KeyError: '08A7'` that crashes the entire integration when a **Schaltaktor 2-fach wireless** ([product page](https://www.busch-jaeger.at/online-katalog/detail/2CKA006710A0056)) is part of the free@home setup.

## Changes

### 1. `names.json` — Added missing device name

Added the entry `"08A7": "Schaltaktor 2-fach wireless"` so the device is recognized correctly.

### 2. `pfreeathome.py` — Made device name lookup resilient

Changed line 752 from:

```python
device_model = names[device_name_id]
```

to:

```python
device_model = names.get(device_name_id, 'Unknown device ' + device_name_id)
```

This ensures that any future unknown device type will show up with a placeholder name instead of crashing the entire integration.