### PR TITLE
Add support for Matter-over-Thread contact and motion sensors (FID 0x0114, 0x0115)

### DIFF
--- a/custom_components/freeathome/fah/const.py
+++ b/custom_components/freeathome/fah/const.py
@@ -57,6 +57,8 @@ FUNCTION_IDS_BINARY_SENSOR = [
         0x00A0, # FID_DOMUS_SMOKE_DETECTOR
         0x00C0, # FID_SMOKE_DETECTOR_TYPE1
         0x007E, # FID_CARBON_MONOXIDE_SENSOR
+        0x0114, # FID_SENSOR_DOOR_WINDOW_BASIC: Matter-over-Thread door/window contact sensor
+        0x0115, # FID_SENSOR_MOVEMENT_BASIC: Matter-over-Thread motion/presence sensor
         ]
 
 FUNCTION_IDS_SWITCHING_ACTUATOR = [


### PR DESCRIPTION
## Summary

Adds support for two Matter-over-Thread device types that are paired via
the free@home Matter Stick and visible to the SysAP, but were previously
not recognized by the integration:

- **FID 0x0114**: Door/window contact sensor (e.g. tink Basic
  Tür-/Fenstersensor, device id 0163)
- **FID 0x0115**: Motion/presence sensor (e.g. Eve Motion, device id 0164)

## Root cause

`FahBinarySensor.pairing_ids()` checks `if function_id in
FUNCTION_IDS_BINARY_SENSOR`. These two function IDs were missing from
that list, so `pairing_ids()` returned `None` and no HA entity was
created — even though the SysAP correctly exposes the devices and all
required PID constants are already defined in `const.py`.

## Evidence

Debug log during integration reload shows the devices being found but
silently skipped (no `add device` line follows):

```
# tink Basic contact sensor
Encountered serialnumber 600030E42A91, channel_id ch0000, function ID 276
['dp odp0000 pid 0x0035/53 nameid 012E']
# → no "add device" follows

# Eve Motion (Matter-over-Thread)
Encountered serialnumber 6000B6C38AE7, channel_id ch0000, function ID 277
['dp odp0000 pid 0x0006/6 nameid 02BD',
 'dp odp0001 pid 0x0007/7 nameid 01F6',
 'dp odp0002 pid 0x0403/1027 nameid 0242']
# → no "add device" follows
```

## Fix

Two lines added to `FUNCTION_IDS_BINARY_SENSOR` in `const.py`. No other
changes required — the relevant PIDs (`PID_WINDOW_DOOR`,
`PID_MOVEMENT_UNDER_CONSIDERATION_OF_BRIGHTNESS`, `PID_PRESENCE`) are
already present in `FahBinarySensor.pairing_ids()`'s output list, and
`get_datapoints_by_pairing_ids()` silently skips PIDs absent from the
device (e.g. FID 0x0114 only exposes PID 0x0035, not PID 0x0029).

## Testing

- tink Basic Tür-/Fenstersensor (Matter-over-Thread via free@home Matter
  Stick, SysAP firmware 3.5.4): appears as `binary_sensor` in HA after
  integration reload ✓
- Eve Motion paired to same Matter Stick (FID 0x0115): entity created ✓

I have edited the file on my HA instance locally and checked that the changes work.