### PR TITLE
refactor(freeathome): Modernize entity properties and clean up legacy imports

### DIFF
--- a/custom_components/freeathome/__init__.py
+++ b/custom_components/freeathome/__init__.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import event
-from homeassistant.helpers.discovery import load_platform
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 

--- a/custom_components/freeathome/light.py
+++ b/custom_components/freeathome/light.py
@@ -1,21 +1,13 @@
 """ Support for Free@Home lights dimmers """
 import logging
 
-try:
-    from homeassistant.components.light import (
-        ATTR_BRIGHTNESS,
-        ATTR_RGB_COLOR,
-        ColorMode,
-        LightEntity,
-    )
-except ImportError:  # pragma: no cover
-    from homeassistant.const import ATTR_BRIGHTNESS
-    from homeassistant.components.light import ATTR_RGB_COLOR, ColorMode, LightEntity
-
-try:
-    from homeassistant.components.light import ATTR_COLOR_TEMP_KELVIN
-except ImportError:  # pragma: no cover
-    from homeassistant.const import ATTR_COLOR_TEMP as ATTR_COLOR_TEMP_KELVIN
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
 
 from .const import DOMAIN
 

--- a/custom_components/freeathome/sensor.py
+++ b/custom_components/freeathome/sensor.py
@@ -149,15 +149,15 @@ class FreeAtHomeOtherSensor(FreeAtHomeSensor):
         FreeAtHomeSensor.__init__(self, device)
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the device."""
         if self._unit_of_measurement == UnitOfSpeed.KILOMETERS_PER_HOUR:
             return ("%.2f" % (float(self._state) * 3.6))
-        else:    
+        else:
             return self._state
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 


### PR DESCRIPTION
This PR modernizes the `freeathome` integration by aligning entity implementations and imports with current Home Assistant Core best practices.

### 1. Sensor Property Modernization
Following the Home Assistant entity architecture updates, custom integrations should not override the base `state` property directly on `SensorEntity` derived classes. Instead, they must implement `native_value` and `native_unit_of_measurement` to allow Home Assistant Core to manage unit conversions, rounding, and state machine updates consistently.

- Updated [FreeAtHomeOtherSensor](file:///ramdisk/freeathome/custom_components/freeathome/sensor.py#L147):
  - `state` property -> `native_value` property.
  - `unit_of_measurement` property -> `native_unit_of_measurement` property.

*Reference:* [Home Assistant Developer Documentation: Sensor Entity](https://developers.home-assistant.io/docs/core/entity/sensor/)

### 2. Import Cleanups & Code Styling
- Cleaned up legacy `try-except` import blocks in `light.py` that were previously used for backward compatibility with older Home Assistant versions.
- Removed unused `load_platform` import in `__init__.py`.
- Fixed minor styling issue (removed trailing whitespace in `sensor.py`).

## Type of change
- [x] Refactoring (non-breaking change which improves code structure/cleanliness)

## Verification
The changes have been verified statically. The properties now correctly interface with the newer entity model.