### PR TITLE
Filter cyclic datapoint repetitions in binary sensors (ghost motion events every 840 s)

### DIFF
--- a/custom_components/freeathome/fah/devices/fah_binary_sensor.py
+++ b/custom_components/freeathome/fah/devices/fah_binary_sensor.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 
 from .fah_device import FahDevice
 from ..const import (
@@ -28,10 +29,26 @@ from ..const import (
 
 LOG = logging.getLogger(__name__)
 
+# free@home cyclically re-sends output datapoints with their last value
+# (observed period: exactly 840 s). These repetitions are keep-alives, not new
+# events, but update_datapoint() cannot tell them apart and sets state to '1'
+# again. If the sensor has been reset to '0' in the meantime, the repetition
+# produces a ghost motion event. Measured on six motion detectors over 7 days:
+# 37 % of all triggers were such repetitions (period 840.0 s, spread below
+# 0.6 s across all six devices); real motion never happened to land on this
+# grid. A repetition is only discarded when it carries the SAME value as the
+# previous telegram of the SAME datapoint and arrives CYCLIC_PERIOD after it.
+CYCLIC_PERIOD = 840.0
+CYCLIC_TOLERANCE = 2.0
+
+
 class FahBinarySensor(FahDevice):
     """Free@Home binary object """
     state = None
     window_position = None
+    # Created lazily per instance on the first telegram (deliberately NOT a
+    # dict literal here: that would be a class attribute shared by all sensors).
+    _cyclic_last = None
 
     def pairing_ids(function_id=None):
         if function_id in FUNCTION_IDS_BINARY_SENSOR:
@@ -74,12 +91,41 @@ class FahBinarySensor(FahDevice):
                     }
 
 
+    def _is_cyclic_repeat(self, dp, value):
+        """True if dp repeats its previous identical value exactly CYCLIC_PERIOD later."""
+        # Never filter safety-critical datapoints.
+        for pid in (PID_FIRE_ALARM_ACTIVE, PID_CO_ALARM_ACTIVE):
+            if self._datapoints.get(pid) == dp:
+                return False
+
+        if self._cyclic_last is None:
+            self._cyclic_last = {}
+
+        now = time.monotonic()
+        previous = self._cyclic_last.get(dp)
+        self._cyclic_last[dp] = (now, value)
+
+        if previous is None:
+            return False
+        last_time, last_value = previous
+        # A changed value is always a real event, never a repetition.
+        if value != last_value:
+            return False
+        return abs((now - last_time) - CYCLIC_PERIOD) <= CYCLIC_TOLERANCE
+
     def update_datapoint(self, dp, value):
         """Receive updated datapoint."""
         if self._datapoints.get(PID_WINDOW_DOOR_POSITION) == dp:
             self.window_position = value
-        else:
-            self.state = '0' if value == '0' else '1'
+            LOG.info("binary sensor %s (%s) dp %s state %s", self.name, self.lookup_key, dp, value)
+            return
+
+        if self._is_cyclic_repeat(dp, value):
+            LOG.debug("binary sensor %s (%s) dp %s: cyclic repeat of value %s ignored",
+                      self.name, self.lookup_key, dp, value)
+            return
+
+        self.state = '0' if value == '0' else '1'
         LOG.info("binary sensor %s (%s) dp %s state %s", self.name, self.lookup_key, dp, value)
 
     def is_fire_sensor(self):

--- a/custom_components/freeathome/tests/test_binary_sensor.py
+++ b/custom_components/freeathome/tests/test_binary_sensor.py
@@ -6,6 +6,12 @@ import logging
 from async_mock import patch, AsyncMock
 
 from fah.pfreeathome import Client
+from fah.devices.fah_binary_sensor import FahBinarySensor, CYCLIC_PERIOD
+from fah.const import (
+        PID_PRESENCE,
+        PID_FIRE_ALARM_ACTIVE,
+        PID_WINDOW_DOOR_POSITION,
+        )
 from common import load_fixture
 
 LOG = logging.getLogger(__name__)
@@ -268,3 +274,99 @@ class TestBinarySensorsCover:
         assert sensor_cover.device_info["model"] == "Sensor/ Jalousieaktor 1/1-fach"
         assert sensor_cover.device_info["sw_version"] == "2.1366"
         assert sensor_cover.state == "1"
+
+
+class TestCyclicRepeatFilter:
+    """Cyclic keep-alive repetitions must not be reported as new events."""
+
+    def make_sensor(self, datapoints):
+        return FahBinarySensor(
+                None, {}, "ABB700D12345", "ch0000", "0001", "Sensor", datapoints)
+
+    async def test_cyclic_repeat_is_ignored(self):
+        sensor = self.make_sensor({PID_PRESENCE: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0001", "1")
+        assert sensor.state == "1"
+
+        # Home Assistant resets the sensor after the movement has ended
+        sensor.state = "0"
+
+        # Exactly one cycle later, the same value arrives again
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0001", "1")
+        assert sensor.state == "0"
+
+    async def test_changed_value_is_never_filtered(self):
+        sensor = self.make_sensor({PID_PRESENCE: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0001", "0")
+        assert sensor.state == "0"
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0001", "1")
+        assert sensor.state == "1"
+
+    async def test_real_event_off_the_grid_is_kept(self):
+        sensor = self.make_sensor({PID_PRESENCE: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0001", "1")
+        sensor.state = "0"
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1300.0):
+            sensor.update_datapoint("odp0001", "1")
+        assert sensor.state == "1"
+
+    async def test_fire_alarm_is_never_filtered(self):
+        sensor = self.make_sensor({PID_FIRE_ALARM_ACTIVE: "odp0000"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0000", "1")
+        sensor.state = "0"
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0000", "1")
+        assert sensor.state == "1"
+
+    async def test_datapoints_are_tracked_separately(self):
+        sensor = self.make_sensor({PID_PRESENCE: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0001", "1")
+        sensor.state = "0"
+
+        # Different datapoint, so this is not a repetition of the one above
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0002", "1")
+        assert sensor.state == "1"
+
+    async def test_sensors_do_not_share_state(self):
+        first = self.make_sensor({PID_PRESENCE: "odp0001"})
+        second = self.make_sensor({PID_PRESENCE: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            first.update_datapoint("odp0001", "1")
+        second.state = "0"
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            second.update_datapoint("odp0001", "1")
+        assert second.state == "1"
+
+    async def test_window_position_is_unaffected(self):
+        sensor = self.make_sensor({PID_WINDOW_DOOR_POSITION: "odp0001"})
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0001", "50")
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0001", "50")
+        assert sensor.window_position == "50"
+        assert sensor.state is None


### PR DESCRIPTION
## The problem

free@home cyclically re-sends output datapoints with their last value as a keep-alive. For motion detectors this means: exactly **840 seconds** after a real motion telegram (`odp0001`), the SysAP repeats the same telegram with the same value.

`FahBinarySensor.update_datapoint()` treats every incoming datapoint as a fresh event (`self.state = '0' if value == '0' else '1'`). If the sensor has been reset to `0` in the meantime, the repetition flips it back to `1` and Home Assistant sees a motion event that never happened.

Measured impact in my installation (6 motion detectors, 7 days, 914 triggers): **37 % of all motion triggers were these repetitions**. The period was 840.0 s with a spread below 0.6 s across all six devices, and the prediction "next ghost event = last odp0001 + 840 s" was accurate to the second for 6 out of 6 detectors. Real motion never landed on this grid (control check with a fake 780 s period matched only 6.7 %, which is the random baseline).

My setup happens to have two independent SysAPs, and the detectors on both showed the same 840 s period with the same spread. That makes it look like SysAP behavior rather than something specific to my installation, but I can only speak for what I measured.

This makes any alarm automation built on these sensors unusable: leaving the house inevitably triggers the detectors, and 840 seconds later the echo fires into the armed system.

## The fix

This touches the shared code path of all binary sensors, so the filter is written to be as narrow as possible: it only ever discards a telegram that is provably redundant, and every other case falls through to the existing behavior unchanged.

A repetition is discarded **only** when it carries the **same value** as the previous telegram of the **same datapoint** and arrives `CYCLIC_PERIOD` (840 s, tolerance 2 s) after it:

- A changed value is always treated as a real event.
- Fire and CO alarm datapoints are never filtered (fail-safe).
- Filtering by time distance instead of "only accept `odp0000`" is deliberate: some devices (in my case a motion detector used for night switching, and one in a guest WC) never send `odp0000`; their real motion also arrives as `odp0001` only. The time filter keeps them fully functional, because a real motion resets the cycle and therefore never lands on the 840 s grid.
- Window position datapoints are unaffected (early return, unchanged behavior).

The per-instance state is created lazily inside the instance, not as a class-level dict, so sensors do not share it.

## Tests

Seven cases added to `tests/test_binary_sensor.py`, covering: repetition ignored, changed value never filtered, real event off the grid kept, fire alarm never filtered, datapoints tracked separately, sensors not sharing state, window position unaffected. The full suite passes (42 tests).

## Verification in production

Running live since 2026-07-15:

- Immediately after deployment: all six detectors kept reporting real motion; 6 of 6 echoes were discarded.
- 35.5 h check: 234 triggers, 4.3 % on the 840 s grid vs. 3.8 % on the 780 s control grid (random level).
- **14-day long-term check (2026-07-17 to 2026-07-31): 509 triggers, 3.9 % on the 840 s grid vs. 6.1 % on the control grid.** The echoes are gone; before the patch the same measurement gave 37.1 %.
- No lost detectors and no missed real motion over the whole period (the installation ran an armed vacation mode with camera cross-checking for 11 of those days).

Happy to adjust naming or style if you prefer something different.