### PR TITLE
Add a reauth flow for the credentials, keep reconfigure for the host

### DIFF
--- a/custom_components/freeathome/__init__.py
+++ b/custom_components/freeathome/__init__.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import event
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
@@ -78,10 +79,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         
     sysap.component_path = hass.config.path("custom_components")    
 
-    hass.data[DOMAIN][entry.entry_id] = sysap
-
     await sysap.connect()
-    await sysap.wait_for_connection()
+    if not await sysap.wait_for_connection():
+        # Stop the client, otherwise it keeps a reconnect loop running
+        # in the background for every failed setup attempt.
+        await sysap.disconnect()
+        raise ConfigEntryNotReady(f"Cannot connect to free@home SysAP at {entry.data[CONF_HOST]}")
+
+    hass.data[DOMAIN][entry.entry_id] = sysap
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, sysap.shutdown)
 

--- a/custom_components/freeathome/__init__.py
+++ b/custom_components/freeathome/__init__.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import event
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
@@ -81,10 +81,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await sysap.connect()
     if not await sysap.wait_for_connection():
+        # Read the reason before disconnecting.
+        auth_failed = sysap.authentication_in_error()
         # Stop the client, otherwise it keeps a reconnect loop running
         # in the background for every failed setup attempt.
         await sysap.disconnect()
+        if auth_failed:
+            raise ConfigEntryAuthFailed(f"Login rejected by free@home SysAP at {entry.data[CONF_HOST]}")
         raise ConfigEntryNotReady(f"Cannot connect to free@home SysAP at {entry.data[CONF_HOST]}")
+
+    # Only from here on the entry exists, so a rejected login is reported
+    # through the reauth flow instead of the exception above. A login that is
+    # rejected later, for example after the password was changed in free@home,
+    # would otherwise stay invisible until the next restart.
+    reauth_started = False
+
+    def _handle_rejected_login():
+        # The client retries a rejected login every few seconds, so run once.
+        # Unloading drops this callback, a new setup registers a fresh one.
+        nonlocal reauth_started
+        if reauth_started:
+            return
+        reauth_started = True
+        entry.async_start_reauth(hass)
+        # Reload so the setup runs again and raises ConfigEntryAuthFailed.
+        # That puts the entry visibly into an error state; without it the
+        # entry would stay green while every login is being rejected. It
+        # also stops the retry loop of the client.
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+    sysap.set_auth_failed_callback(_handle_rejected_login)
 
     hass.data[DOMAIN][entry.entry_id] = sysap
 
@@ -161,6 +187,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     sysap = hass.data[DOMAIN][entry.entry_id]
+    # Drop the callback first, so an entry that is being removed cannot open
+    # a reauth dialog on the way out.
+    sysap.set_auth_failed_callback(None)
     await sysap.disconnect()
 
     if unload_ok:

--- a/custom_components/freeathome/config_flow.py
+++ b/custom_components/freeathome/config_flow.py
@@ -41,10 +41,15 @@ async def validate_input(hass: core.HomeAssistant, data: dict):
     await sysap.connect()
 
     result = await sysap.wait_for_connection()
-    if not result:
-        raise CannotConnect
+    # Read the reason before disconnecting.
+    auth_failed = sysap.authentication_in_error()
 
     await sysap.disconnect()
+
+    if not result:
+        if auth_failed:
+            raise InvalidAuth
+        raise CannotConnect
 
     return {"title": data[CONF_HOST]}
 
@@ -141,6 +146,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(title=info["title"], data=user_input)
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
@@ -164,60 +171,105 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Link a config entry from discovery."""
         return await self.async_step_user(user_input)
 
-    async def async_step_reconfigure(self, user_input=None):
-        """Reconfigure an existing entry, e.g. after a password change."""
+    async def async_step_reauth(self, entry_data):
+        """Start reauth after the SysAP rejected the stored credentials."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Ask for the credentials again and check them against the SysAP."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         errors = {}
 
         if user_input is not None:
-            host = user_input[CONF_HOST]
-            username = user_input[CONF_USERNAME]
-
-            if check_ip_adress(host):
-                ip_adress = host
-            else:
-                # maybe it is a hostname
-                ip_adress = get_host_name_ip(host)
-                if ip_adress is None:
-                    errors[CONF_HOST] = "unknown_host"
+            # The host is deliberately not part of this form. A changed host is
+            # not an authentication problem and belongs in the reconfigure step.
+            data = {**entry.data, **user_input}
+            errors = await self._validate_against_sysap(data, entry)
 
             if not errors:
-                settings = SettingsFah(ip_adress)
-                found = await settings.load_json()
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data=data,
+                    reason="reauth_successful",
+                )
 
-                if found:
-                    jid = settings.get_jid(username)
-                    if jid is None:
-                        errors[CONF_USERNAME] = "unknown_user"
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=_reauth_schema_with_defaults(entry.data),
+            errors=errors,
+            description_placeholders={CONF_HOST: entry.data[CONF_HOST]},
+        )
 
-                    serial_number = settings.get_flag("serialNumber")
-                    new_unique_id = serial_number if serial_number else ip_adress
-                    if entry.unique_id and new_unique_id != entry.unique_id:
-                        errors[CONF_HOST] = "other_sysap"
-                else:
-                    errors[CONF_HOST] = "no_sysap"
-                    _LOGGER.info("not a sysap")
+    async def async_step_reconfigure(self, user_input=None):
+        """Reconfigure an existing entry, e.g. after the SysAP changed address."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        errors = {}
+
+        if user_input is not None:
+            # Username and password are not part of this form; they belong in
+            # reauth. The stored credentials are what prove that the host given
+            # here is reachable and is still the same SysAP.
+            data = {**entry.data, **user_input}
+            errors = await self._validate_against_sysap(data, entry)
 
             if not errors:
-                try:
-                    await validate_input(self.hass, user_input)
-                except CannotConnect:
-                    errors["base"] = "cannot_connect"
-                except Exception:  # pylint: disable=broad-except
-                    _LOGGER.exception("Unexpected exception")
-                    errors["base"] = "unknown"
-                else:
-                    return self.async_update_reload_and_abort(
-                        entry,
-                        data={**entry.data, **user_input},
-                        reason="reconfigure_successful",
-                    )
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data=data,
+                    reason="reconfigure_successful",
+                )
 
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=_reconfigure_schema_with_defaults(user_input or entry.data),
             errors=errors,
         )
+
+    async def _validate_against_sysap(self, data, entry):
+        """Run the checks of the initial setup against a complete data set.
+
+        Returns the errors for the form, empty if everything checks out.
+        """
+        errors = {}
+
+        host = data[CONF_HOST]
+        if check_ip_adress(host):
+            ip_adress = host
+        else:
+            # maybe it is a hostname
+            ip_adress = get_host_name_ip(host)
+            if ip_adress is None:
+                return {CONF_HOST: "unknown_host"}
+
+        settings = SettingsFah(ip_adress)
+        found = await settings.load_json()
+        if not found:
+            _LOGGER.info("not a sysap")
+            return {CONF_HOST: "no_sysap"}
+
+        jid = settings.get_jid(data[CONF_USERNAME])
+        if jid is None:
+            errors[CONF_USERNAME] = "unknown_user"
+
+        serial_number = settings.get_flag("serialNumber")
+        new_unique_id = serial_number if serial_number else ip_adress
+        if entry.unique_id and new_unique_id != entry.unique_id:
+            errors[CONF_HOST] = "other_sysap"
+
+        if errors:
+            return errors
+
+        try:
+            await validate_input(self.hass, data)
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+
+        return errors
 
     async def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
@@ -244,6 +296,10 @@ class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
 
 
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate the SysAP rejected the credentials."""
+
+
 def _discovery_schema_with_defaults(discovery_info):
     return vol.Schema(_ordered_shared_schema(discovery_info))
 
@@ -257,14 +313,21 @@ def _user_schema_with_defaults(user_input):
     return vol.Schema(user_schema)
 
 
-def _reconfigure_schema_with_defaults(schema_input):
+def _reauth_schema_with_defaults(schema_input):
     # No default for the password: it must be entered anew, so a stale
     # stored value can never be written back unnoticed.
     return vol.Schema(
         {
-            vol.Required(CONF_HOST, default=schema_input.get(CONF_HOST, "")): str,
             vol.Required(CONF_USERNAME, default=schema_input.get(CONF_USERNAME, "")): str,
             vol.Required(CONF_PASSWORD): str,
+        }
+    )
+
+
+def _reconfigure_schema_with_defaults(schema_input):
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=schema_input.get(CONF_HOST, "")): str,
             vol.Optional(
                 CONF_USE_ROOM_NAMES,
                 default=schema_input.get(CONF_USE_ROOM_NAMES, DEFAULT_USE_ROOM_NAMES),

--- a/custom_components/freeathome/config_flow.py
+++ b/custom_components/freeathome/config_flow.py
@@ -164,6 +164,61 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Link a config entry from discovery."""
         return await self.async_step_user(user_input)
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Reconfigure an existing entry, e.g. after a password change."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        errors = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            username = user_input[CONF_USERNAME]
+
+            if check_ip_adress(host):
+                ip_adress = host
+            else:
+                # maybe it is a hostname
+                ip_adress = get_host_name_ip(host)
+                if ip_adress is None:
+                    errors[CONF_HOST] = "unknown_host"
+
+            if not errors:
+                settings = SettingsFah(ip_adress)
+                found = await settings.load_json()
+
+                if found:
+                    jid = settings.get_jid(username)
+                    if jid is None:
+                        errors[CONF_USERNAME] = "unknown_user"
+
+                    serial_number = settings.get_flag("serialNumber")
+                    new_unique_id = serial_number if serial_number else ip_adress
+                    if entry.unique_id and new_unique_id != entry.unique_id:
+                        errors[CONF_HOST] = "other_sysap"
+                else:
+                    errors[CONF_HOST] = "no_sysap"
+                    _LOGGER.info("not a sysap")
+
+            if not errors:
+                try:
+                    await validate_input(self.hass, user_input)
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data={**entry.data, **user_input},
+                        reason="reconfigure_successful",
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_reconfigure_schema_with_defaults(user_input or entry.data),
+            errors=errors,
+        )
+
     async def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
         if not user_input:
@@ -200,6 +255,26 @@ def _user_schema_with_defaults(user_input):
     user_schema.update(_ordered_shared_schema(user_input))
 
     return vol.Schema(user_schema)
+
+
+def _reconfigure_schema_with_defaults(schema_input):
+    # No default for the password: it must be entered anew, so a stale
+    # stored value can never be written back unnoticed.
+    return vol.Schema(
+        {
+            vol.Required(CONF_HOST, default=schema_input.get(CONF_HOST, "")): str,
+            vol.Required(CONF_USERNAME, default=schema_input.get(CONF_USERNAME, "")): str,
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(
+                CONF_USE_ROOM_NAMES,
+                default=schema_input.get(CONF_USE_ROOM_NAMES, DEFAULT_USE_ROOM_NAMES),
+            ): bool,
+            vol.Optional(
+                CONF_SWITCH_AS_X,
+                default=schema_input.get(CONF_SWITCH_AS_X, DEFAULT_SWITCH_AS_X),
+            ): bool,
+        }
+    )
 
 
 def _ordered_shared_schema(schema_input):

--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -399,6 +399,9 @@ class Client(slixmpp.ClientXMPP):
     def failed_auth(self, event):
         """ If the password in the config is wrong  """
         LOG.error('Free@Home : authentication failed, probably wrong password')
+        # Mark the connection as failed before the disconnected event arrives,
+        # so wait_for_connection() cannot report success in between.
+        self.connect_in_error = True
         self.connect_finished = True
 
     async def set_datapoint(self, serialnumber, channel_id, datapoint, command):

--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -262,6 +262,8 @@ class Client(slixmpp.ClientXMPP):
     use_room_names = False
     switch_as_x = False
     connect_in_error = False
+    auth_in_error = False
+    auth_failed_callback = None
 
     # The specific devices
     devices = set()
@@ -345,6 +347,10 @@ class Client(slixmpp.ClientXMPP):
         """For checking if connection is in error or not"""
         return self.connect_in_error
 
+    def authentication_in_error(self):
+        """For checking if the connection failed on authentication"""
+        return self.auth_in_error
+
     def sysap_connect(self):
         LOG.info('Connect: %s %s', self._host, self._port )
         super(Client, self).connect(self._host, self._port)
@@ -403,6 +409,12 @@ class Client(slixmpp.ClientXMPP):
         # so wait_for_connection() cannot report success in between.
         self.connect_in_error = True
         self.connect_finished = True
+        # Kept apart from connect_in_error, so the caller can tell a rejected
+        # login from an unreachable SysAP.
+        self.auth_in_error = True
+
+        if self.auth_failed_callback is not None:
+            self.auth_failed_callback()
 
     async def set_datapoint(self, serialnumber, channel_id, datapoint, command):
         """ Send a command to the sysap   """
@@ -931,6 +943,9 @@ class FreeAtHomeSysApp(object):
         self._switch_as_x = False
         self.reconnect = True
         self._component_path = ''
+        # Optional plain callable, invoked when the SysAP rejects the login.
+        # Keeps this module free of any Home Assistant import.
+        self.auth_failed_callback = None
 
     @property
     def host(self):
@@ -986,6 +1001,7 @@ class FreeAtHomeSysApp(object):
                 iterations, salt = settings.get_scram_settings(self._user, 'SCRAM-SHA-256')
             # create xmpp client
             self.xmpp = Client(self._jid, self._password, self._host, self._port, fahversion, iterations, salt, self.reconnect, self._component_path)
+            self.xmpp.auth_failed_callback = self.auth_failed_callback
             # connect
             self.xmpp.sysap_connect()
 
@@ -1002,6 +1018,18 @@ class FreeAtHomeSysApp(object):
     async def shutdown(self, event=None):
         LOG.info("Detecting shutdown home assistant")
         await self.disconnect()
+
+    def set_auth_failed_callback(self, callback):
+        """ Register a callable that is invoked when the sysap rejects the login """
+        self.auth_failed_callback = callback
+        # Also reaches a client that is already connected, so the caller can
+        # register the callback after a successful setup.
+        if self.xmpp is not None:
+            self.xmpp.auth_failed_callback = callback
+
+    def authentication_in_error(self):
+        """ True if the last attempt failed on authentication, not on the connection """
+        return self.xmpp is not None and self.xmpp.authentication_in_error()
 
     async def wait_for_connection(self):
         """ Wait til connection is made, if failed at first attempt retry until success """

--- a/custom_components/freeathome/strings.json
+++ b/custom_components/freeathome/strings.json
@@ -11,12 +11,18 @@
           "switch_as_x": "[%key:common::config_flow::data::switch_as_x%]"
         }
       },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The free@home SysAP at {host} rejected the stored credentials. Enter them again; they are checked against the SysAP before they are saved.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "reconfigure": {
-        "description": "Update the connection settings of your free@home SysAP, for example after a password change. The settings are checked against the SysAP before they are saved.",
+        "description": "Update the connection settings of your free@home SysAP, for example after it moved to a different address. The settings are checked against the SysAP before they are saved. Use the re-authentication dialog to change username or password.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
           "use_room_names": "Use room names",
           "switch_as_x": "[%key:common::config_flow::data::switch_as_x%]"
         }
@@ -24,12 +30,14 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "other_sysap": "This host is a different SysAP than the one this entry was set up for"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "Cannot connect to discovered free@home SysAP",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }

--- a/custom_components/freeathome/strings.json
+++ b/custom_components/freeathome/strings.json
@@ -10,15 +10,27 @@
           "use_room_names": "Use room names",
           "switch_as_x": "[%key:common::config_flow::data::switch_as_x%]"
         }
+      },
+      "reconfigure": {
+        "description": "Update the connection settings of your free@home SysAP, for example after a password change. The settings are checked against the SysAP before they are saved.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "use_room_names": "Use room names",
+          "switch_as_x": "[%key:common::config_flow::data::switch_as_x%]"
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "other_sysap": "This host is a different SysAP than the one this entry was set up for"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "Cannot connect to discovered free@home SysAP"
+      "cannot_connect": "Cannot connect to discovered free@home SysAP",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/custom_components/freeathome/translations/de.json
+++ b/custom_components/freeathome/translations/de.json
@@ -20,20 +20,27 @@
 	  "use_room_names": "Use room names"
         }
       },
+      "reauth_confirm": {
+        "title": "Free@Home",
+        "description": "Der free@home SysAP unter {host} hat die gespeicherten Anmeldedaten abgelehnt. Gib sie erneut ein. Die Eingaben werden vor dem Speichern gegen den SysAP geprüft.",
+        "data": {
+          "username": "Benutzername",
+          "password": "Passwort"
+        }
+      },
       "reconfigure": {
         "title": "Free@Home",
-        "description": "Aktualisiere die Verbindungsdaten deines free@home SysAP, zum Beispiel nach einer Passwort-Änderung. Die Eingaben werden vor dem Speichern gegen den SysAP geprüft.",
+        "description": "Aktualisiere die Verbindungsdaten deines free@home SysAP, zum Beispiel nach einem Wechsel der Adresse. Die Eingaben werden vor dem Speichern gegen den SysAP geprüft. Benutzername und Passwort änderst du über die erneute Anmeldung.",
         "data": {
           "host": "Host",
-          "username": "Benutzername",
-          "password": "Passwort",
           "use_room_names": "Raumnamen verwenden",
           "switch_as_x": "Funktion switch_as_x verwenden (schaltende Geräte in HA als Schalter anlegen)"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect (probably wrong password)",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Anmeldung fehlgeschlagen: Der SysAP hat Benutzername oder Passwort abgelehnt",
       "unknown": "Unexpected error",
       "unknown_host": "Connection error: please check your host",
       "no_sysap": "Connection error: this host is not a sysap", 
@@ -43,6 +50,7 @@
     "abort": {
       "already_configured": "Already configured. Only a single configuration possible.",
       "cannot_connect": "Failed to connect",
+      "reauth_successful": "Die erneute Anmeldung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
   }  

--- a/custom_components/freeathome/translations/de.json
+++ b/custom_components/freeathome/translations/de.json
@@ -19,6 +19,17 @@
           "password": "Password",
 	  "use_room_names": "Use room names"
         }
+      },
+      "reconfigure": {
+        "title": "Free@Home",
+        "description": "Aktualisiere die Verbindungsdaten deines free@home SysAP, zum Beispiel nach einer Passwort-Änderung. Die Eingaben werden vor dem Speichern gegen den SysAP geprüft.",
+        "data": {
+          "host": "Host",
+          "username": "Benutzername",
+          "password": "Passwort",
+          "use_room_names": "Raumnamen verwenden",
+          "switch_as_x": "Funktion switch_as_x verwenden (schaltende Geräte in HA als Schalter anlegen)"
+        }
       }
     },
     "error": {
@@ -26,11 +37,13 @@
       "unknown": "Unexpected error",
       "unknown_host": "Connection error: please check your host",
       "no_sysap": "Connection error: this host is not a sysap", 
-      "unknown_user": "Login error: please check your username"
+      "unknown_user": "Login error: please check your username",
+      "other_sysap": "Unter diesem Host antwortet ein anderer SysAP als der, der in diesem Eintrag eingerichtet ist"
     },
     "abort": {
       "already_configured": "Already configured. Only a single configuration possible.",
-      "cannot_connect": "Failed to connect"
+      "cannot_connect": "Failed to connect",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
   }  
 }

--- a/custom_components/freeathome/translations/en.json
+++ b/custom_components/freeathome/translations/en.json
@@ -21,6 +21,17 @@
 	        "use_room_names": "Use room names",
           "switch_as_x": "Use switch_as_x feature (configure switching devices as switches in HA)"
         }
+      },
+      "reconfigure": {
+        "title": "Free@Home",
+        "description": "Update the connection settings of your free@home SysAP, for example after a password change. The settings are checked against the SysAP before they are saved.",
+        "data": {
+          "host": "Host",
+          "username": "Username",
+          "password": "Password",
+          "use_room_names": "Use room names",
+          "switch_as_x": "Use switch_as_x feature (configure switching devices as switches in HA)"
+        }
       }
     },
     "error": {
@@ -28,11 +39,13 @@
       "unknown": "Unexpected error",
       "unknown_host": "Connection error: please check your host",
       "no_sysap": "Connection error: this host is not a sysap", 
-      "unknown_user": "Login error: please check your username"
+      "unknown_user": "Login error: please check your username",
+      "other_sysap": "This host is a different SysAP than the one this entry was set up for"
     },
     "abort": {
       "already_configured": "Already configured. Only a single configuration possible.",
-      "cannot_connect": "Failed to connect"
+      "cannot_connect": "Failed to connect",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   }  
 }

--- a/custom_components/freeathome/translations/en.json
+++ b/custom_components/freeathome/translations/en.json
@@ -22,20 +22,27 @@
           "switch_as_x": "Use switch_as_x feature (configure switching devices as switches in HA)"
         }
       },
+      "reauth_confirm": {
+        "title": "Free@Home",
+        "description": "The free@home SysAP at {host} rejected the stored credentials. Enter them again; they are checked against the SysAP before they are saved.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
       "reconfigure": {
         "title": "Free@Home",
-        "description": "Update the connection settings of your free@home SysAP, for example after a password change. The settings are checked against the SysAP before they are saved.",
+        "description": "Update the connection settings of your free@home SysAP, for example after it moved to a different address. The settings are checked against the SysAP before they are saved. Use the re-authentication dialog to change username or password.",
         "data": {
           "host": "Host",
-          "username": "Username",
-          "password": "Password",
           "use_room_names": "Use room names",
           "switch_as_x": "Use switch_as_x feature (configure switching devices as switches in HA)"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect (probably wrong password)",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication: the SysAP rejected the username or password",
       "unknown": "Unexpected error",
       "unknown_host": "Connection error: please check your host",
       "no_sysap": "Connection error: this host is not a sysap", 
@@ -45,6 +52,7 @@
     "abort": {
       "already_configured": "Already configured. Only a single configuration possible.",
       "cannot_connect": "Failed to connect",
+      "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Re-configuration was successful"
     }
   }  

--- a/custom_components/freeathome/translations/nl.json
+++ b/custom_components/freeathome/translations/nl.json
@@ -17,6 +17,17 @@
           "username": "Gebruiker",
           "password": "Wachtwoord"
         }
+      },
+      "reconfigure": {
+        "title": "Free@Home",
+        "description": "Werk de verbindingsgegevens van de free@home SysAP bij, bijvoorbeeld na een wachtwoordwijziging. De invoer wordt eerst gecontroleerd bij de SysAP en daarna opgeslagen.",
+        "data": {
+          "host": "Host",
+          "username": "Gebruiker",
+          "password": "Wachtwoord",
+          "use_room_names": "Kamernamen gebruiken",
+          "switch_as_x": "Functie switch_as_x gebruiken (schakelende apparaten in HA als schakelaar aanmaken)"
+        }
       }
     },
     "error": {
@@ -24,11 +35,13 @@
       "unknown": "Onverwachte fout",
       "unknown_host": "Verbindingsfout: controleer de host",
       "no_sysap": "Verbindingsfout: Deze host is is geen sysap", 
-      "unknown_user": "Inlogfout: controleer de gebruikersnaam"
+      "unknown_user": "Inlogfout: controleer de gebruikersnaam",
+      "other_sysap": "Deze host is een andere SysAP dan die van deze configuratie"
     },
     "abort": {
       "already_configured": "Host is al geconfigureerd",
-      "cannot_connect": "Kan geen verbinding maken"
+      "cannot_connect": "Kan geen verbinding maken",
+      "reconfigure_successful": "Herconfiguratie geslaagd"
     }
   }
 }

--- a/custom_components/freeathome/translations/nl.json
+++ b/custom_components/freeathome/translations/nl.json
@@ -18,20 +18,27 @@
           "password": "Wachtwoord"
         }
       },
+      "reauth_confirm": {
+        "title": "Free@Home",
+        "description": "De free@home SysAP op {host} heeft de opgeslagen inloggegevens geweigerd. Voer ze opnieuw in. De invoer wordt eerst gecontroleerd bij de SysAP en daarna opgeslagen.",
+        "data": {
+          "username": "Gebruiker",
+          "password": "Wachtwoord"
+        }
+      },
       "reconfigure": {
         "title": "Free@Home",
-        "description": "Werk de verbindingsgegevens van de free@home SysAP bij, bijvoorbeeld na een wachtwoordwijziging. De invoer wordt eerst gecontroleerd bij de SysAP en daarna opgeslagen.",
+        "description": "Werk de verbindingsgegevens van de free@home SysAP bij, bijvoorbeeld na een adreswijziging. De invoer wordt eerst gecontroleerd bij de SysAP en daarna opgeslagen. Gebruiker en wachtwoord wijzig je via het opnieuw aanmelden.",
         "data": {
           "host": "Host",
-          "username": "Gebruiker",
-          "password": "Wachtwoord",
           "use_room_names": "Kamernamen gebruiken",
           "switch_as_x": "Functie switch_as_x gebruiken (schakelende apparaten in HA als schakelaar aanmaken)"
         }
       }
     },
     "error": {
-      "cannot_connect": "Kan geen verbinding maken (waarschijnlijk een fout wachtwoord)",
+      "cannot_connect": "Kan geen verbinding maken",
+      "invalid_auth": "Aanmelden mislukt: de SysAP heeft de gebruiker of het wachtwoord geweigerd",
       "unknown": "Onverwachte fout",
       "unknown_host": "Verbindingsfout: controleer de host",
       "no_sysap": "Verbindingsfout: Deze host is is geen sysap", 
@@ -41,6 +48,7 @@
     "abort": {
       "already_configured": "Host is al geconfigureerd",
       "cannot_connect": "Kan geen verbinding maken",
+      "reauth_successful": "Opnieuw aanmelden geslaagd",
       "reconfigure_successful": "Herconfiguratie geslaagd"
     }
   }


### PR DESCRIPTION
## Summary

The integration asks for host, username and password only during the first setup. When the password changes in free@home, there is no screen to update it; #200 asks for exactly that. The first version of this PR put the credentials into a reconfigure flow. As discussed in the comments below, credentials belong in a reauth flow, so I reworked the PR: username and password now live in a reauth flow, and the reconfigure step keeps the host and the two options.

Fixes #200

## What the reauth flow does

- `async_setup_entry` raises `ConfigEntryAuthFailed` when the SysAP rejects the login during setup. Home Assistant then marks the entry and starts the reauth flow by itself. To tell a rejected login from an unreachable SysAP, the client records it in a new `auth_in_error` marker next to the existing connection error flag.
- A login that is rejected at runtime, for example after a password change in free@home, is reported through an optional callback: it starts the reauth flow and reloads the entry once. The entry then shows an error state with a reason text instead of staying loaded, and the reconnect loop of the client stops. The callback is a plain function, so the fah package stays free of Home Assistant imports.
- The dialog names the host in its description, prefills the username and has no host field. The password field is always empty, so a stored password is never shown or written back unnoticed. The input runs through the same checks as the initial setup, including the serial number comparison against the entry unique_id, and is saved only when the SysAP accepts it.
- One behavior change: before this PR the client kept retrying a rejected login (the reconnect handler waits two seconds and connects again, with no stop condition), so the connection healed itself when the old password came back. Now the entry waits in the error state for the reauth dialog. I think a rejected login is a case for a human.

## What the reconfigure flow keeps

- Host and the two options (use_room_names, switch_as_x). Username and password are no longer part of this form; its description now points to the re-authentication dialog for credentials.
- Both flows share the validation in one helper (_validate_against_sysap), including the other_sysap protection from the first version of this PR.
- The initial setup form now returns the invalid_auth error for a rejected login instead of the generic cannot_connect.

## Compatibility

The flow avoids the reauth helpers that came with core 2024.11 (`_get_reauth_entry`, `_abort_if_unique_id_mismatch`, `data_updates`). It uses `entry.async_start_reauth`, which exists since at least core 2022.7.

## Testing

- The existing test suite passes with 35 tests, before and after the change.
- Home Assistant pytest harness (pytest-homeassistant-custom-component, HA 2025.1), SysAP mocked: a login rejected at runtime puts a loaded entry into the error state and opens exactly one reauth flow, also when the callback fires more than once. Without the rework the entry stays loaded and the test fails. The test is not part of this PR because the existing suite does not use the harness; I can contribute it separately.
- Live on my own installation (Home Assistant 2026.8.2, two SysAPs, this integration at V1.0.10 plus this patch): I changed the password of the Home Assistant user in free@home while the entry was loaded. Within seconds the entry showed the error state with the reason text and the reauth dialog appeared, exactly once; the log shows three rejected attempts and then silence, no retry loop. The second SysAP stayed loaded and untouched. After I entered the new password in the dialog, the entry reloaded and a sensor of this SysAP delivered fresh values again.
