### PR TITLE
Keep device state per client, so multiple SysAPs no longer mix

### DIFF
--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -265,12 +265,6 @@ class Client(slixmpp.ClientXMPP):
     auth_in_error = False
     auth_failed_callback = None
 
-    # The specific devices
-    devices = set()
-    monitored_datapoints = {}
-    monitored_parameters = {}
-
-    _update_handlers = []
     
     def _create_lg_ssl_context() -> ssl.SSLContext:
         """Create a SSL context for Free@Home."""
@@ -284,6 +278,15 @@ class Client(slixmpp.ClientXMPP):
     def __init__(self, jid, password, host, port, fahversion, iterations=None, salt=None, reconnect=True, component_path=''):
         """x"""
         slixmpp.ClientXMPP.__init__(self, jid, password, sasl_mech="SCRAM-SHA-1", ssl_context=self._SSL_CONTEXT)
+
+        # Per instance, never on the class. With more than one SysAP every
+        # client would otherwise fill the same containers, so each config
+        # entry sees the devices of all SysAPs and Home Assistant rejects
+        # the duplicates with "does not generate unique IDs".
+        self.devices = set()
+        self.monitored_datapoints = {}
+        self.monitored_parameters = {}
+        self._update_handlers = []
 
         self.fahversion = fahversion
         self.x_jid = jid

--- a/custom_components/freeathome/tests/common.py
+++ b/custom_components/freeathome/tests/common.py
@@ -5,3 +5,16 @@ def load_fixture(filename):
     path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
     with open(path, encoding="utf-8") as fptr:
         return fptr.read()
+
+
+def init_client_state(client, *args, **kwargs):
+    """Set up the per instance state that Client.__init__ creates.
+
+    Tests replace the constructor, so they have to bring the containers
+    themselves. Without them the tests would fall back on class attributes
+    and share their state, which is exactly what the code no longer does.
+    """
+    client.devices = set()
+    client.monitored_datapoints = {}
+    client.monitored_parameters = {}
+    client._update_handlers = []

--- a/custom_components/freeathome/tests/test_binary_sensor.py
+++ b/custom_components/freeathome/tests/test_binary_sensor.py
@@ -12,14 +12,12 @@ from fah.const import (
         PID_FIRE_ALARM_ACTIVE,
         PID_WINDOW_DOOR_POSITION,
         )
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
-    client.monitored_datapoints = {}
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -28,7 +26,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_client.py
+++ b/custom_components/freeathome/tests/test_client.py
@@ -1,0 +1,32 @@
+import pytest
+
+from fah.pfreeathome import Client
+
+
+def make_client(host):
+    """Build a client without connecting to anything."""
+    return Client(f"user@{host}/hass", "secret", host, 5222, "2.2.0")
+
+
+def test_clients_do_not_share_their_state():
+    """Every SysAP keeps its own devices, whatever their number.
+
+    The containers used to be class attributes, so every client filled the
+    same ones. With more than one SysAP each config entry then tried to add
+    the entities of all of them, and Home Assistant rejected the duplicates
+    with "Platform freeathome does not generate unique IDs".
+    """
+    clients = [make_client(f"192.0.2.{number}") for number in (1, 2, 3)]
+
+    for number, client in enumerate(clients):
+        device = f"device of SysAP {number}"
+        client.devices.add(device)
+        client.monitored_datapoints[f"ABB00000000{number}/ch0000/odp0000"] = device
+        client.monitored_parameters[f"ABB00000000{number}/ch0000/par0000"] = device
+        client.add_update_handler(lambda message: None)
+
+    for number, client in enumerate(clients):
+        assert client.devices == {f"device of SysAP {number}"}
+        assert list(client.monitored_datapoints) == [f"ABB00000000{number}/ch0000/odp0000"]
+        assert list(client.monitored_parameters) == [f"ABB00000000{number}/ch0000/par0000"]
+        assert len(client._update_handlers) == 1

--- a/custom_components/freeathome/tests/test_climate.py
+++ b/custom_components/freeathome/tests/test_climate.py
@@ -6,13 +6,12 @@ import logging
 from async_mock import call, patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -21,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_cover.py
+++ b/custom_components/freeathome/tests/test_cover.py
@@ -6,13 +6,12 @@ import logging
 from async_mock import call, patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -21,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_light.py
+++ b/custom_components/freeathome/tests/test_light.py
@@ -6,14 +6,12 @@ import logging
 from async_mock import call,patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
-    client.monitored_datapoints = {}
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -22,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_lock.py
+++ b/custom_components/freeathome/tests/test_lock.py
@@ -6,14 +6,12 @@ import logging
 from async_mock import call,patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
-    client.monitored_datapoints = {}
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -22,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_scene.py
+++ b/custom_components/freeathome/tests/test_scene.py
@@ -6,14 +6,12 @@ import logging
 from async_mock import call,patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
-    client.monitored_datapoints = {}
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -22,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)

--- a/custom_components/freeathome/tests/test_sensor.py
+++ b/custom_components/freeathome/tests/test_sensor.py
@@ -6,14 +6,12 @@ import logging
 from async_mock import patch, AsyncMock
 
 from fah.pfreeathome import Client
-from common import load_fixture
+from common import load_fixture, init_client_state
 
 LOG = logging.getLogger(__name__)
 
 def get_client():
     client = Client()
-    client.devices = set()
-    client.monitored_datapoints = {}
     client.set_datapoint = AsyncMock()
     client._host = "localhost"
     client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -22,7 +20,7 @@ def get_client():
 
 @pytest.fixture(autouse=True)
 def mock_init():
-    with patch("fah.pfreeathome.Client.__init__", return_value=None):
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
         yield
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## The symptom

My installation runs two System Access Points. Every restart wrote 268 errors like this one into the log:

```
Platform freeathome does not generate unique IDs. ID ABB700D12345/ch000B already exists - ignoring binary_sensor.example_sensor
```

The serial number and the entity name in this example are anonymised.

262 of those 268 lines belong to 110 real devices. I measured that in the core log on 2026-08-20.

## What I found

`Client` keeps four mutable containers as class attributes:

```python
class Client(slixmpp.ClientXMPP):
    devices = set()                 # line 269
    monitored_datapoints = {}       # line 270
    monitored_parameters = {}       # line 271

    _update_handlers = []           # line 273
```

In Python every instance shares such a container. Both SysAP connections therefore filled the same four. Each config entry then read the devices of both installations during setup and tried to add entities for all of them. The entry that loaded first won, the second one failed per device.

The collision does not come from shared hardware. After the change every remaining error stands for one serial number and channel that both SysAPs hand out, and exactly one error is left. So out of all devices in both installations exactly one collides, and that one is virtual.

## The entities end up on the wrong entry

Before the change all 266 enabled entities belonged to one entry. The other entry owned seven entities, and all seven were disabled door lock entities. Three motion detectors belonged to the wrong entry, although those devices sit on the other SysAP. An outage of a single SysAP stays invisible that way, and it misled me once while I was tracking down a different fault.

## The change

Nine lines. The four containers now belong to the instance.

## No entity is lost

That was my main worry, because my automations depend on the entity ids. The `unique_id` stays what it was, serial number plus channel. I read the registry code of Home Assistant 2026.8.2 before I tried anything:

- `entity_registry.async_get_or_create` finds an existing `unique_id` and then only calls `_async_update_entity`. The `entity_id` stays, only `config_entry_id` moves.
- `device_registry.async_cleanup` removes a device only if no config entry **and** no entity references it. Both keep referencing it here.

Then I ran it on my installation. The result after the restart:

| | before | after |
|---|---|---|
| errors per restart | 268 | 1 |
| enabled entities on entry A | 266 | 96 |
| enabled entities on entry B | 0 | 170 |
| changed entity ids | | none of 273 |
| entities unavailable | | 0 of 266 |

The three motion detectors now belong to the entry of the SysAP they sit on.

## Any number of SysAPs

The change does not depend on the number two. The test covers three clients. I also checked the syntax tree for further mutable class attributes on `Client`, there are none left.

## Tests

`tests/test_client.py` is new: three clients must not share their state. Without the change it fails.

While writing it I noticed that the existing tests replace the constructor and inherited the containers from the class. 31 of 43 tests failed after my change for that reason. They now bring the containers along themselves, through `init_client_state` in `tests/common.py`. The suite is green again, 44 tests.

## What is left

One virtual system device still collides. Both SysAPs ship a light group under `FFFF40000002`, so one error per restart remains.

In my two installations every virtual device, so light groups and scenes, carries a `FFFF...` serial number, and every real device carries a hardware serial that is unique on its own. Putting the SysAP in front of the unique id of the virtual devices would clear the last error. It would also make the light groups and scenes of the second SysAP visible, which they are not today.

I left it out of this change, and it needs this change first: while both entries still read the devices of both SysAPs, there is no way to tell which SysAP a virtual device belongs to.

It does not have to cost an entity id, though. `entity_registry.async_update_entity(entity_id, new_unique_id=...)` renames a registry entry and leaves the entity id alone, so history, area and automations survive (Home Assistant 2026.8.3, `homeassistant/helpers/entity_registry.py`). I have that follow-up written and tested here, and I can offer it as a separate pull request if you want it.

## How common is this

Probably rare. I would guess that few installations run more than one SysAP. It bothered me enough to look into it.