### PR TITLE
Feature/dimming sensor events

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,27 @@ Recently a change has been made to the way switches are exposed in Home Assistan
 Any new installation of this custom component will have `switch_as_x` set to `True` by default. This means that all switches will be exposed as `switch`es and you'll be able to use the HA [switch_as_x](https://www.home-assistant.io/integrations/switch_as_x/) feature. If you want to expose them as `light`s, you can set `switch_as_x` to `False` in your configuration.yaml.
 
 ## Events
-Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire an event when pressed. The event type is `freeathome_event` and contains the following actuator's information:
+Actuators that are exposed in Home Assistant as binary sensors (typically wall switches) fire `freeathome_event` events. Normal switch datapoints continue to emit `pressed`. Dimming sensors additionally emit `dim_start` while a rocker is held and `dim_stop` when it is released.
 
-| Key          | Type   | Example                                     |
-|--------------|--------|---------------------------------------------|
-| name         | string | Actuator Hallway                            |
-| serialnumber | string | ABB700CE9999                                |
-| unique_id    | string | ABB700CE9999/ch0000                         |
-| state        | bool   | true for on / false for off                 |
-| command      | string | "pressed" is the only option at this moment |
+| Key          | Type   | Example                                      |
+|--------------|--------|----------------------------------------------|
+| name         | string | Sensor/Dimmaktor 1/1-fach                    |
+| serialnumber | string | ABB700CE9999                                 |
+| unique_id    | string | ABB700CE9999/ch0000                          |
+| state        | bool   | true / false for `pressed` events            |
+| command      | string | `pressed`, `dim_start`, or `dim_stop`        |
+| direction    | string | `up` or `down` for relative dimming events   |
 
-The event fires regardless of the state of the binary sensory in Home Assistant and Free@Home. Each time the wall switch is pressed, the event fires.
+Relative dimming is decoded from the Free@Home Relative Set Value datapoint (pairing ID `0010`, KNX DPT 3.007). A capture from a Free@Home Sensor/Dimmaktor confirmed the following values:
+
+| Raw value | Command     | Direction |
+|-----------|-------------|-----------|
+| `9`       | `dim_start` | `up`      |
+| `8`       | `dim_stop`  | `up`      |
+| `1`       | `dim_start` | `down`    |
+| `0`       | `dim_stop`  | `down`    |
+
+The direction is retained on `dim_stop`, because DPT 3.007 carries the direction bit in both stop values. Other valid DPT 3.007 step codes are decoded in the same way.
 
 These events can be used in automations. For example to turn on a light every time the actuator's "on" button is pressed:
 ```
@@ -75,6 +85,26 @@ action:
       entity_id:
       - light.nice_lamp
 ```
+
+For example, a brightness-increase action can start when the upper rocker is held:
+```
+trigger:
+  - platform: event
+    event_type: freeathome_event
+    event_data:
+      unique_id: ABB700CE9999/ch0000
+      command: dim_start
+      direction: up
+action:
+  - service: light.turn_on
+    target:
+      entity_id: light.nice_lamp
+    data:
+      brightness_step_pct: 10
+      transition: 1
+```
+
+Listen for `command: dim_stop` with the same `unique_id` to stop a repeating brightness action when the rocker is released.
 
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ action:
 
 Listen for `command: dim_stop` with the same `unique_id` to stop a repeating brightness action when the rocker is released.
 
+### Dimmer status sensor
+
+Each detected two-sided dimming channel also creates an enum sensor on its
+existing Free@Home device. It shows the last rocker action using exactly four
+states. Single pushbutton channels keep the bus events described above, but do
+not get this four-state sensor because they have no upper/lower rocker pair.
+
+| State          | Meaning               |
+|----------------|-----------------------|
+| `pressed_up`   | Upper rocker pressed  |
+| `pressed_down` | Lower rocker pressed  |
+| `held_up`      | Upper rocker held     |
+| `held_down`    | Lower rocker held     |
+
+Home Assistant translates these states for display. A release still emits the
+`dim_stop` event described above and deliberately leaves the last action visible
+on the status sensor.
+
 
 ## Debugging
 

--- a/custom_components/freeathome/binary_sensor.py
+++ b/custom_components/freeathome/binary_sensor.py
@@ -2,6 +2,7 @@
 import logging
 from homeassistant.components.binary_sensor import (BinarySensorEntity, BinarySensorDeviceClass)
 from .const import DOMAIN
+from .fah_event import create_event_data
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,19 +89,17 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
             """Call after device was updated."""
             await self.async_update_ha_state(True)
 
+        async def datapoint_updated_callback(device, event):
+            """Fire an event containing the decoded datapoint command."""
+            eventdata = create_event_data(
+                self._name, device.serialnumber, self.unique_id, event)
+            self._hass.bus.async_fire("freeathome_event", eventdata)
+
         self.binary_device.register_device_updated_cb(after_update_callback)
+        self.binary_device.register_datapoint_updated_cb(datapoint_updated_callback)
 
     async def async_update(self):
         """Retrieve latest state."""
 
         self._state = (self.binary_device.state == '1')
         _LOGGER.info('update sensor')
-
-        eventdata = {
-            "name"        : self._name,
-            "serialnumber": self.binary_device.serialnumber,
-            "unique_id"   : self.unique_id,
-            "state"       : self._state,
-            "command"     : "pressed"
-        }
-        self._hass.bus.async_fire("freeathome_event", eventdata)

--- a/custom_components/freeathome/binary_sensor.py
+++ b/custom_components/freeathome/binary_sensor.py
@@ -97,6 +97,12 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
 
         self.binary_device.register_device_updated_cb(after_update_callback)
         self.binary_device.register_datapoint_updated_cb(datapoint_updated_callback)
+        self.async_on_remove(
+            lambda: self.binary_device.unregister_device_cb(
+                after_update_callback))
+        self.async_on_remove(
+            lambda: self.binary_device.unregister_datapoint_updated_cb(
+                datapoint_updated_callback))
 
     async def async_update(self):
         """Retrieve latest state."""

--- a/custom_components/freeathome/fah/const.py
+++ b/custom_components/freeathome/fah/const.py
@@ -61,6 +61,14 @@ FUNCTION_IDS_BINARY_SENSOR = [
         0x0115, # FID_SENSOR_MOVEMENT_BASIC: Matter-over-Thread motion/presence sensor
         ]
 
+FUNCTION_IDS_DIMMING_STATUS = [
+        0x0001, # Dimming sensor
+        0x0031, # FID_PANEL_DIMMING_SENSOR
+        0x1010, # FID_DIMMING_SENSOR_ROCKER_TYPE0
+        0x1011, # FID_DIMMING_SENSOR_ROCKER_TYPE1
+        0x1012, # FID_DIMMING_SENSOR_ROCKER_TYPE2
+        ]
+
 FUNCTION_IDS_SWITCHING_ACTUATOR = [
         0x0007, # Switch actuator
         0x0045, # Trigger

--- a/custom_components/freeathome/fah/devices/fah_binary_sensor.py
+++ b/custom_components/freeathome/fah/devices/fah_binary_sensor.py
@@ -5,6 +5,7 @@ import time
 from .fah_device import FahDevice
 from ..const import (
         FUNCTION_IDS_BINARY_SENSOR,
+        FUNCTION_IDS_DIMMING_STATUS,
         FUNCTION_IDS_WEATHER_STATION,
         PID_SWITCH_ON_OFF,
         PID_TIMED_START_STOP,
@@ -200,6 +201,11 @@ class FahBinarySensor(FahDevice):
     def is_co_sensor(self):
         """Return true if device is a dimmer"""
         return PID_CO_ALARM_ACTIVE in self._datapoints
+
+    def supports_dimming_status(self):
+        """Return true if this channel provides two-sided dimming actions."""
+        return (self._function_id in FUNCTION_IDS_DIMMING_STATUS and
+                PID_RELATIVE_SET_VALUE in self._datapoints)
 
     def update_parameter(self, param, value):
         LOG.debug("Not yet implemented")

--- a/custom_components/freeathome/fah/devices/fah_binary_sensor.py
+++ b/custom_components/freeathome/fah/devices/fah_binary_sensor.py
@@ -46,9 +46,12 @@ class FahBinarySensor(FahDevice):
     """Free@Home binary object """
     state = None
     window_position = None
-    # Created lazily per instance on the first telegram (deliberately NOT a
-    # dict literal here: that would be a class attribute shared by all sensors).
-    _cyclic_last = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cyclic_last = {}
+        self._datapoint_updated_cbs = []
+        self._pending_datapoint_events = []
 
     def pairing_ids(function_id=None):
         if function_id in FUNCTION_IDS_BINARY_SENSOR:
@@ -98,9 +101,6 @@ class FahBinarySensor(FahDevice):
             if self._datapoints.get(pid) == dp:
                 return False
 
-        if self._cyclic_last is None:
-            self._cyclic_last = {}
-
         now = time.monotonic()
         previous = self._cyclic_last.get(dp)
         self._cyclic_last[dp] = (now, value)
@@ -112,6 +112,46 @@ class FahBinarySensor(FahDevice):
         if value != last_value:
             return False
         return abs((now - last_time) - CYCLIC_PERIOD) <= CYCLIC_TOLERANCE
+
+    def register_datapoint_updated_cb(self, datapoint_updated_cb):
+        """Register a callback that receives decoded datapoint events."""
+        self._datapoint_updated_cbs.append(datapoint_updated_cb)
+
+    def unregister_datapoint_updated_cb(self, datapoint_updated_cb):
+        """Unregister a decoded datapoint event callback."""
+        self._datapoint_updated_cbs.remove(datapoint_updated_cb)
+
+    async def after_update(self):
+        """Update the device and deliver all datapoint events in order."""
+        pending_events = self._pending_datapoint_events
+        self._pending_datapoint_events = []
+
+        await super().after_update()
+
+        for event in pending_events:
+            for datapoint_updated_cb in self._datapoint_updated_cbs:
+                await datapoint_updated_cb(self, event)
+
+    def _relative_dimming_event(self, value):
+        """Decode a Free@Home Relative Set Value (KNX DPT 3.007)."""
+        try:
+            raw_value = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if not 0 <= raw_value <= 0x0f:
+            return None
+
+        direction = "up" if raw_value & 0x08 else "down"
+        step_code = raw_value & 0x07
+        command = "dim_stop" if step_code == 0 else "dim_start"
+
+        return {
+                "pid": PID_RELATIVE_SET_VALUE,
+                "raw_value": value,
+                "command": command,
+                "direction": direction,
+                }
 
     def update_datapoint(self, dp, value):
         """Receive updated datapoint."""
@@ -125,7 +165,32 @@ class FahBinarySensor(FahDevice):
                       self.name, self.lookup_key, dp, value)
             return
 
+        if self._datapoints.get(PID_RELATIVE_SET_VALUE) == dp:
+            event = self._relative_dimming_event(value)
+            if event is None:
+                LOG.warning("binary sensor %s (%s) dp %s: invalid relative dimming value %s",
+                            self.name, self.lookup_key, dp, value)
+                return
+
+            # Relative dimming is active for every non-zero step code. A zero
+            # step code is the explicit DPT 3.007 stop command, regardless of
+            # the direction bit.
+            self.state = '0' if event["command"] == "dim_stop" else '1'
+            self._pending_datapoint_events.append(event)
+            LOG.info("binary sensor %s (%s) dp %s relative dimming value %s: %s %s",
+                     self.name, self.lookup_key, dp, value,
+                     event["command"], event["direction"])
+            return
+
         self.state = '0' if value == '0' else '1'
+        pid = next((pid for pid, datapoint in self._datapoints.items()
+                    if datapoint == dp), None)
+        self._pending_datapoint_events.append({
+                "pid": pid,
+                "raw_value": value,
+                "command": "pressed",
+                "state": self.state == '1',
+                })
         LOG.info("binary sensor %s (%s) dp %s state %s", self.name, self.lookup_key, dp, value)
 
     def is_fire_sensor(self):

--- a/custom_components/freeathome/fah_event.py
+++ b/custom_components/freeathome/fah_event.py
@@ -1,0 +1,18 @@
+"""Helpers for Free@Home Home Assistant events."""
+
+
+def create_event_data(name, serialnumber, unique_id, event):
+    """Build a freeathome_event payload from a decoded datapoint event."""
+    event_data = {
+        "name": name,
+        "serialnumber": serialnumber,
+        "unique_id": unique_id,
+        "command": event["command"],
+    }
+
+    if "state" in event:
+        event_data["state"] = event["state"]
+    if "direction" in event:
+        event_data["direction"] = event["direction"]
+
+    return event_data

--- a/custom_components/freeathome/fah_event.py
+++ b/custom_components/freeathome/fah_event.py
@@ -1,5 +1,12 @@
 """Helpers for Free@Home Home Assistant events."""
 
+DIMMING_STATUS_OPTIONS = [
+    "pressed_up",
+    "pressed_down",
+    "held_up",
+    "held_down",
+]
+
 
 def create_event_data(name, serialnumber, unique_id, event):
     """Build a freeathome_event payload from a decoded datapoint event."""
@@ -16,3 +23,20 @@ def create_event_data(name, serialnumber, unique_id, event):
         event_data["direction"] = event["direction"]
 
     return event_data
+
+
+def dimming_status_from_event(event):
+    """Return one of the four visible dimming actions for an event."""
+    if event.get("command") == "pressed":
+        if event.get("state") is True:
+            return "pressed_up"
+        if event.get("state") is False:
+            return "pressed_down"
+
+    if event.get("command") == "dim_start":
+        if event.get("direction") == "up":
+            return "held_up"
+        if event.get("direction") == "down":
+            return "held_down"
+
+    return None

--- a/custom_components/freeathome/sensor.py
+++ b/custom_components/freeathome/sensor.py
@@ -27,6 +27,7 @@ else:
 
 from .fah.devices.fah_device import FahDevice
 from .const import DOMAIN
+from .fah_event import DIMMING_STATUS_OPTIONS, dimming_status_from_event
 
 SENSOR_TYPES = {
     "temperature": [
@@ -102,6 +103,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices, discovery_inf
     thermostats = fah.get_devices('thermostat')
     for device_object in thermostats:
         sensors.append(FreeAtHomeThermostatTemperatureSensor(device_object))
+
+    binary_sensors = fah.get_devices('binary_sensor')
+    for device_object in binary_sensors:
+        if device_object.supports_dimming_status():
+            sensors.append(FreeAtHomeDimmingStatusSensor(device_object))
 
     async_add_devices(sensors)
 
@@ -240,3 +246,43 @@ class FreeAtHomeThermostatTemperatureSensor(SensorEntity):
 
     async def async_update(self):
         pass
+
+
+class FreeAtHomeDimmingStatusSensor(SensorEntity):
+    """Expose the last of four dimmer rocker actions as an enum sensor."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_has_entity_name = True
+    _attr_options = DIMMING_STATUS_OPTIONS
+    _attr_translation_key = "dimming_status"
+
+    def __init__(self, device):
+        self.binary_device = device
+        self._attr_device_info = device.device_info
+        self._attr_native_value = None
+        self._attr_translation_placeholders = {
+            "channel_id": device.channel_id,
+        }
+        self._attr_unique_id = f"{device.lookup_key}/dimming_status"
+
+    @property
+    def should_poll(self):
+        """Return that polling is not necessary."""
+        return False
+
+    async def async_added_to_hass(self):
+        """Register the decoded datapoint event callback."""
+        await super().async_added_to_hass()
+
+        async def datapoint_updated_callback(_, event):
+            status = dimming_status_from_event(event)
+            if status is None:
+                return
+            self._attr_native_value = status
+            self.async_write_ha_state()
+
+        self.binary_device.register_datapoint_updated_cb(
+            datapoint_updated_callback)
+        self.async_on_remove(
+            lambda: self.binary_device.unregister_datapoint_updated_cb(
+                datapoint_updated_callback))

--- a/custom_components/freeathome/strings.json
+++ b/custom_components/freeathome/strings.json
@@ -40,5 +40,18 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
+  },
+  "entity": {
+    "sensor": {
+      "dimming_status": {
+        "name": "Dimmer status {channel_id}",
+        "state": {
+          "pressed_up": "Upper rocker pressed",
+          "pressed_down": "Lower rocker pressed",
+          "held_up": "Upper rocker held",
+          "held_down": "Lower rocker held"
+        }
+      }
+    }
   }
 }

--- a/custom_components/freeathome/tests/fixtures/B008_update_dimming_sensor.xml
+++ b/custom_components/freeathome/tests/fixtures/B008_update_dimming_sensor.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project type="update">
+ <devices>
+  <device serialNumber="ABB2E0612345">
+   <channels>
+    <channel i="ch0001">
+     <outputs>
+      <dataPoint i="odp0001" pairingId="0010">
+       <value>9</value>
+      </dataPoint>
+     </outputs>
+    </channel>
+   </channels>
+  </device>
+ </devices>
+</project>

--- a/custom_components/freeathome/tests/test_binary_sensor.py
+++ b/custom_components/freeathome/tests/test_binary_sensor.py
@@ -8,10 +8,13 @@ from async_mock import patch, AsyncMock
 from fah.pfreeathome import Client
 from fah.devices.fah_binary_sensor import FahBinarySensor, CYCLIC_PERIOD
 from fah.const import (
+        PID_RELATIVE_SET_VALUE,
+        PID_SWITCH_ON_OFF,
         PID_PRESENCE,
         PID_FIRE_ALARM_ACTIVE,
         PID_WINDOW_DOOR_POSITION,
         )
+from fah_event import create_event_data
 from common import load_fixture
 
 LOG = logging.getLogger(__name__)
@@ -158,6 +161,20 @@ class TestBinarySensors8Gang:
         assert dimming_sensor.serialnumber == "ABB2E0612345"
         assert dimming_sensor.channel_id == "ch0001"
         assert dimming_sensor.state == "0"
+
+        events = []
+
+        async def callback(_, event):
+            events.append(event)
+
+        dimming_sensor.register_datapoint_updated_cb(callback)
+        await client.update_devices(load_fixture("B008_update_dimming_sensor.xml"))
+        assert events == [{
+                "pid": PID_RELATIVE_SET_VALUE,
+                "raw_value": "9",
+                "command": "dim_start",
+                "direction": "up",
+                }]
 
         # Dimming sensor
         dimming_sensor = next((el for el in sensor_devices if el.lookup_key == "ABB2E0612345/ch0002"))
@@ -370,3 +387,152 @@ class TestCyclicRepeatFilter:
             sensor.update_datapoint("odp0001", "50")
         assert sensor.window_position == "50"
         assert sensor.state is None
+
+
+class TestBinarySensorEvents:
+    """Binary sensor datapoint updates must retain their protocol semantics."""
+
+    def make_sensor(self, datapoints):
+        return FahBinarySensor(
+                None, {}, "ABB7F62FF48B", "ch0000", "0001",
+                "Sensor/Dimmaktor 1/1-fach", datapoints)
+
+    async def collect_event(self, sensor, dp, value):
+        events = []
+
+        async def callback(device, event):
+            assert device is sensor
+            events.append(event)
+
+        sensor.register_datapoint_updated_cb(callback)
+        sensor.update_datapoint(dp, value)
+        await sensor.after_update()
+        sensor.unregister_datapoint_updated_cb(callback)
+        return events
+
+    @pytest.mark.parametrize(
+            ("value", "expected_state"),
+            (("0", False), ("1", True)))
+    async def test_switch_press_remains_backward_compatible(
+            self, value, expected_state):
+        sensor = self.make_sensor({PID_SWITCH_ON_OFF: "odp0000"})
+
+        events = await self.collect_event(sensor, "odp0000", value)
+
+        assert sensor.state == ('1' if expected_state else '0')
+        assert events == [{
+                "pid": PID_SWITCH_ON_OFF,
+                "raw_value": value,
+                "command": "pressed",
+                "state": expected_state,
+                }]
+
+    @pytest.mark.parametrize(
+            ("value", "command", "direction", "expected_state"),
+            (
+                ("9", "dim_start", "up", "1"),
+                ("8", "dim_stop", "up", "0"),
+                ("1", "dim_start", "down", "1"),
+                ("0", "dim_stop", "down", "0"),
+            ))
+    async def test_relative_dimming_capture_values(
+            self, value, command, direction, expected_state):
+        # Values captured from ABB7F62FF48B/ch0000, PID 0x0010, on 2026-08-27.
+        sensor = self.make_sensor({PID_RELATIVE_SET_VALUE: "odp0003"})
+
+        events = await self.collect_event(sensor, "odp0003", value)
+
+        assert sensor.state == expected_state
+        assert events == [{
+                "pid": PID_RELATIVE_SET_VALUE,
+                "raw_value": value,
+                "command": command,
+                "direction": direction,
+                }]
+
+    @pytest.mark.parametrize(
+            ("start_value", "stop_value", "direction"),
+            (("9", "8", "up"), ("1", "0", "down")))
+    async def test_relative_dimming_events_are_delivered_in_order(
+            self, start_value, stop_value, direction):
+        sensor = self.make_sensor({PID_RELATIVE_SET_VALUE: "odp0003"})
+        events = []
+
+        async def callback(_, event):
+            events.append(event)
+
+        sensor.register_datapoint_updated_cb(callback)
+        sensor.update_datapoint("odp0003", start_value)
+        sensor.update_datapoint("odp0003", stop_value)
+        await sensor.after_update()
+
+        assert [event["command"] for event in events] == ["dim_start", "dim_stop"]
+        assert [event["direction"] for event in events] == [direction, direction]
+
+    async def test_relative_value_on_unrelated_datapoint_is_not_decoded(self):
+        sensor = self.make_sensor({PID_SWITCH_ON_OFF: "odp0000"})
+
+        events = await self.collect_event(sensor, "odp0000", "9")
+
+        assert events[0]["command"] == "pressed"
+        assert "direction" not in events[0]
+
+    async def test_cyclic_relative_dimming_repeat_is_ignored(self):
+        sensor = self.make_sensor({PID_RELATIVE_SET_VALUE: "odp0003"})
+        events = []
+
+        async def callback(_, event):
+            events.append(event)
+
+        sensor.register_datapoint_updated_cb(callback)
+        with patch("fah.devices.fah_binary_sensor.time.monotonic", return_value=1000.0):
+            sensor.update_datapoint("odp0003", "9")
+        await sensor.after_update()
+
+        with patch("fah.devices.fah_binary_sensor.time.monotonic",
+                   return_value=1000.0 + CYCLIC_PERIOD):
+            sensor.update_datapoint("odp0003", "9")
+        await sensor.after_update()
+
+        assert len(events) == 1
+
+    @pytest.mark.parametrize(
+            ("event", "expected"),
+            (
+                (
+                    {"command": "pressed", "state": True},
+                    {
+                        "name": "Sensor/Dimmaktor 1/1-fach",
+                        "serialnumber": "ABB7F62FF48B",
+                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "command": "pressed",
+                        "state": True,
+                    },
+                ),
+                (
+                    {"command": "dim_start", "direction": "up"},
+                    {
+                        "name": "Sensor/Dimmaktor 1/1-fach",
+                        "serialnumber": "ABB7F62FF48B",
+                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "command": "dim_start",
+                        "direction": "up",
+                    },
+                ),
+                (
+                    {"command": "dim_stop", "direction": "down"},
+                    {
+                        "name": "Sensor/Dimmaktor 1/1-fach",
+                        "serialnumber": "ABB7F62FF48B",
+                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "command": "dim_stop",
+                        "direction": "down",
+                    },
+                ),
+            ))
+    async def test_home_assistant_event_payload(self, event, expected):
+        assert create_event_data(
+                "Sensor/Dimmaktor 1/1-fach",
+                "ABB7F62FF48B",
+                "ABB7F62FF48B/ch0000",
+                event) == expected

--- a/custom_components/freeathome/tests/test_binary_sensor.py
+++ b/custom_components/freeathome/tests/test_binary_sensor.py
@@ -14,7 +14,11 @@ from fah.const import (
         PID_FIRE_ALARM_ACTIVE,
         PID_WINDOW_DOOR_POSITION,
         )
-from fah_event import create_event_data
+from fah_event import (
+        DIMMING_STATUS_OPTIONS,
+        create_event_data,
+        dimming_status_from_event,
+        )
 from common import load_fixture
 
 LOG = logging.getLogger(__name__)
@@ -161,6 +165,7 @@ class TestBinarySensors8Gang:
         assert dimming_sensor.serialnumber == "ABB2E0612345"
         assert dimming_sensor.channel_id == "ch0001"
         assert dimming_sensor.state == "0"
+        assert dimming_sensor.supports_dimming_status()
 
         events = []
 
@@ -392,10 +397,30 @@ class TestCyclicRepeatFilter:
 class TestBinarySensorEvents:
     """Binary sensor datapoint updates must retain their protocol semantics."""
 
-    def make_sensor(self, datapoints):
+    def make_sensor(self, datapoints, function_id=0x1010):
         return FahBinarySensor(
-                None, {}, "ABB7F62FF48B", "ch0000", "0001",
+                None, {}, "ABB700D12345", "ch0000", function_id,
                 "Sensor/Dimmaktor 1/1-fach", datapoints)
+
+    @pytest.mark.parametrize("function_id", (0x0001, 0x0031, 0x1010, 0x1012))
+    async def test_verified_dimming_functions_are_detected(self, function_id):
+        sensor = self.make_sensor(
+                {PID_RELATIVE_SET_VALUE: "odp0003"}, function_id)
+
+        assert sensor.supports_dimming_status()
+
+    @pytest.mark.parametrize("function_id", (0x0000, 0x1018, 0x101A))
+    async def test_non_rocker_relative_datapoint_has_no_four_state_sensor(
+            self, function_id):
+        sensor = self.make_sensor(
+                {PID_RELATIVE_SET_VALUE: "odp0003"}, function_id)
+
+        assert not sensor.supports_dimming_status()
+
+    async def test_dimming_function_without_relative_datapoint_is_not_exposed(self):
+        sensor = self.make_sensor({PID_SWITCH_ON_OFF: "odp0000"})
+
+        assert not sensor.supports_dimming_status()
 
     async def collect_event(self, sensor, dp, value):
         events = []
@@ -437,7 +462,7 @@ class TestBinarySensorEvents:
             ))
     async def test_relative_dimming_capture_values(
             self, value, command, direction, expected_state):
-        # Values captured from ABB7F62FF48B/ch0000, PID 0x0010, on 2026-08-27.
+        # Values captured from a Sensor/Dimmaktor 1/1-fach on 2026-08-27.
         sensor = self.make_sensor({PID_RELATIVE_SET_VALUE: "odp0003"})
 
         events = await self.collect_event(sensor, "odp0003", value)
@@ -503,8 +528,8 @@ class TestBinarySensorEvents:
                     {"command": "pressed", "state": True},
                     {
                         "name": "Sensor/Dimmaktor 1/1-fach",
-                        "serialnumber": "ABB7F62FF48B",
-                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "serialnumber": "ABB700D12345",
+                        "unique_id": "ABB700D12345/ch0000",
                         "command": "pressed",
                         "state": True,
                     },
@@ -513,8 +538,8 @@ class TestBinarySensorEvents:
                     {"command": "dim_start", "direction": "up"},
                     {
                         "name": "Sensor/Dimmaktor 1/1-fach",
-                        "serialnumber": "ABB7F62FF48B",
-                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "serialnumber": "ABB700D12345",
+                        "unique_id": "ABB700D12345/ch0000",
                         "command": "dim_start",
                         "direction": "up",
                     },
@@ -523,8 +548,8 @@ class TestBinarySensorEvents:
                     {"command": "dim_stop", "direction": "down"},
                     {
                         "name": "Sensor/Dimmaktor 1/1-fach",
-                        "serialnumber": "ABB7F62FF48B",
-                        "unique_id": "ABB7F62FF48B/ch0000",
+                        "serialnumber": "ABB700D12345",
+                        "unique_id": "ABB700D12345/ch0000",
                         "command": "dim_stop",
                         "direction": "down",
                     },
@@ -533,6 +558,27 @@ class TestBinarySensorEvents:
     async def test_home_assistant_event_payload(self, event, expected):
         assert create_event_data(
                 "Sensor/Dimmaktor 1/1-fach",
-                "ABB7F62FF48B",
-                "ABB7F62FF48B/ch0000",
+                "ABB700D12345",
+                "ABB700D12345/ch0000",
                 event) == expected
+
+    @pytest.mark.parametrize(
+            ("event", "expected"),
+            (
+                ({"command": "pressed", "state": True}, "pressed_up"),
+                ({"command": "pressed", "state": False}, "pressed_down"),
+                ({"command": "dim_start", "direction": "up"}, "held_up"),
+                ({"command": "dim_start", "direction": "down"}, "held_down"),
+                ({"command": "dim_stop", "direction": "up"}, None),
+                ({"command": "dim_stop", "direction": "down"}, None),
+            ))
+    async def test_dimming_status_mapping(self, event, expected):
+        assert dimming_status_from_event(event) == expected
+
+    async def test_dimming_status_has_exactly_four_options(self):
+        assert DIMMING_STATUS_OPTIONS == [
+                "pressed_up",
+                "pressed_down",
+                "held_up",
+                "held_down",
+                ]

--- a/custom_components/freeathome/translations/de.json
+++ b/custom_components/freeathome/translations/de.json
@@ -53,6 +53,18 @@
       "reauth_successful": "Die erneute Anmeldung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
-  }  
+  },
+  "entity": {
+    "sensor": {
+      "dimming_status": {
+        "name": "Dimmerstatus {channel_id}",
+        "state": {
+          "pressed_up": "Oben gedrückt",
+          "pressed_down": "Unten gedrückt",
+          "held_up": "Oben gehalten",
+          "held_down": "Unten gehalten"
+        }
+      }
+    }
+  }
 }
-

--- a/custom_components/freeathome/translations/en.json
+++ b/custom_components/freeathome/translations/en.json
@@ -55,6 +55,18 @@
       "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Re-configuration was successful"
     }
-  }  
+  },
+  "entity": {
+    "sensor": {
+      "dimming_status": {
+        "name": "Dimmer status {channel_id}",
+        "state": {
+          "pressed_up": "Upper rocker pressed",
+          "pressed_down": "Lower rocker pressed",
+          "held_up": "Upper rocker held",
+          "held_down": "Lower rocker held"
+        }
+      }
+    }
+  }
 }
-

--- a/custom_components/freeathome/translations/nl.json
+++ b/custom_components/freeathome/translations/nl.json
@@ -51,5 +51,18 @@
       "reauth_successful": "Opnieuw aanmelden geslaagd",
       "reconfigure_successful": "Herconfiguratie geslaagd"
     }
+  },
+  "entity": {
+    "sensor": {
+      "dimming_status": {
+        "name": "Dimmerstatus {channel_id}",
+        "state": {
+          "pressed_up": "Boven ingedrukt",
+          "pressed_down": "Onder ingedrukt",
+          "held_up": "Boven vastgehouden",
+          "held_down": "Onder vastgehouden"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Free@Home dimming sensors currently lose the relative dimming command before it
reaches Home Assistant. `PID_RELATIVE_SET_VALUE` is reduced to a binary state,
and the binary sensor platform consequently reports every update as `pressed`.

This change keeps the existing short-press events and adds the actual dimming
start/stop information from the bus. It also exposes the last rocker action as
an enum sensor on the existing Free@Home device.

## Protocol mapping

I recorded the telegrams from a Sensor/Dimmaktor 1/1-fach while pressing and
holding both sides of the rocker. Pairing ID `0010` uses KNX DPT 3.007 and sent:

| Value | Meaning |
| --- | --- |
| `9` | start dimming up |
| `8` | stop dimming up |
| `1` | start dimming down |
| `0` | stop dimming down |

The decoder uses the direction bit and step code, so the other valid DPT 3.007
step values are handled as well. No timing heuristic is involved.

## Changes

- Preserve the datapoint ID and raw value until callbacks have received the
  decoded command.
- Emit `dim_start` with `direction: up` or `direction: down`.
- Emit `dim_stop` on release, retaining the direction from the telegram.
- Keep `command: pressed` and its boolean `state` for normal switch datapoints.
- Add a four-state enum sensor for two-sided dimming channels:
  `pressed_up`, `pressed_down`, `held_up`, and `held_down`.
- Keep the enum at the last action when the rocker is released; `dim_stop`
  remains available as the release event.
- Add English, German, and Dutch entity translations and update the README.

Single dimming pushbuttons still produce the bus events, but do not get the
four-state sensor because they do not have an upper/lower rocker pair.

## Testing

- `71 passed` in `custom_components/freeathome/tests`
- `python3 -m compileall -q custom_components/freeathome`
- JSON validation for `strings.json` and all translations
- `ha core check`
- Tested on Home Assistant 2026.8.3 with a real Sensor/Dimmaktor 1/1-fach

The live test produced all four enum states and both `dim_stop` directions.
Existing short-press automations continued to receive `command: pressed` with
the same boolean `state` field