### PR TITLE
Scope the unique id of virtual devices to their SysAP

### DIFF
--- a/custom_components/freeathome/__init__.py
+++ b/custom_components/freeathome/__init__.py
@@ -6,12 +6,13 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import event
+from homeassistant.helpers import entity_registry as er, event
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 
 from datetime import datetime
 
+from .migration import migrate_unique_ids
 from .const import DOMAIN, CONF_USE_ROOM_NAMES, DEFAULT_USE_ROOM_NAMES, CONF_SWITCH_AS_X, DEFAULT_SWITCH_AS_X, BACKWARD_COMPATIBILE_SWITCH_AS_X
 
 PLATFORMS = [
@@ -77,7 +78,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("No switch_as_x option found in saved config, consider adding it")
         sysap.switch_as_x = BACKWARD_COMPATIBILE_SWITCH_AS_X
         
-    sysap.component_path = hass.config.path("custom_components")    
+    sysap.component_path = hass.config.path("custom_components")
+
+    # Tells the virtual devices of this SysAP apart from those of another one.
+    # Their serial number is the same on every SysAP. The unique id of the
+    # entry is the serial number of the SysAP, so it survives a new IP address.
+    sysap.sysap_id = entry.unique_id or entry.entry_id
 
     await sysap.connect()
     if not await sysap.wait_for_connection():
@@ -117,6 +123,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, sysap.shutdown)
 
     await sysap.find_devices()
+
+    migrate_unique_ids(er.async_get(hass), sysap, DOMAIN)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)           
 

--- a/custom_components/freeathome/binary_sensor.py
+++ b/custom_components/freeathome/binary_sensor.py
@@ -45,7 +45,7 @@ class FreeAtHomeBinarySensor(BinarySensorEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.binary_device.serialnumber + '/' + self.binary_device.channel_id
+        return self.binary_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/climate.py
+++ b/custom_components/freeathome/climate.py
@@ -94,7 +94,7 @@ class FreeAtHomeThermostat(ClimateEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.thermostat_device.serialnumber + '/' + self.thermostat_device.channel_id
+        return self.thermostat_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/cover.py
+++ b/custom_components/freeathome/cover.py
@@ -78,7 +78,7 @@ class FreeAtHomeCover(CoverEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.cover_device.serialnumber + '/' + self.cover_device.channel_id
+        return self.cover_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/fah/devices/fah_device.py
+++ b/custom_components/freeathome/fah/devices/fah_device.py
@@ -1,3 +1,9 @@
+# Virtual devices, so light groups, scenes and the "all lamps" entry, do not sit
+# on the bus. Every SysAP hands out the same FFFF... serial for them, while a
+# real device carries a hardware serial that is unique across SysAPs.
+VIRTUAL_SERIAL_PREFIX = "FFFF"
+
+
 class FahDevice:
     """ Free@Home base object """
 
@@ -56,3 +62,29 @@ class FahDevice:
     def lookup_key(self):
         """Return device lookup key"""
         return self.serialnumber + "/" + self.channel_id
+
+    @property
+    def unique_id(self):
+        """Return the id Home Assistant keeps in the entity registry.
+
+        A hardware serial is unique on its own, so those devices keep the plain
+        lookup key, which is what every existing installation already has in
+        its registry. A virtual serial repeats on every SysAP, so with more
+        than one SysAP the second one would collide with the first and Home
+        Assistant would drop its entities. Those get the SysAP in front.
+
+        The device registry is left alone. Two SysAPs still share one device
+        entry for their virtual devices, since device_info identifies them by
+        the bare serial number. That costs a shared device card, no entity.
+        Splitting them as well would need a device registry migration on top.
+        """
+        if not self.serialnumber.startswith(VIRTUAL_SERIAL_PREFIX):
+            return self.lookup_key
+
+        # Falls back to the plain key while no SysAP is set, for example in a
+        # test that builds a device without a client.
+        sysap_id = getattr(self.client, "sysap_id", "")
+        if not sysap_id:
+            return self.lookup_key
+
+        return sysap_id + "/" + self.lookup_key

--- a/custom_components/freeathome/fah/pfreeathome.py
+++ b/custom_components/freeathome/fah/pfreeathome.py
@@ -294,6 +294,9 @@ class Client(slixmpp.ClientXMPP):
         self._port = port
         self.reconnect = reconnect
         self.component_path = component_path
+        # Identifies the SysAP in the unique id of its virtual devices. Set by
+        # the caller, since only Home Assistant knows the config entry.
+        self.sysap_id = ''
 
         LOG.info(' version: %s', self.fahversion)
 
@@ -948,6 +951,7 @@ class FreeAtHomeSysApp(object):
         self._switch_as_x = False
         self.reconnect = True
         self._component_path = ''
+        self._sysap_id = ''
         # Optional plain callable, invoked when the SysAP rejects the login.
         # Keeps this module free of any Home Assistant import.
         self.auth_failed_callback = None
@@ -987,6 +991,16 @@ class FreeAtHomeSysApp(object):
         """ setter component_path   """
         self._component_path = value
 
+    @property
+    def sysap_id(self):
+        """ getter sysap_id   """
+        return self._sysap_id
+
+    @sysap_id.setter
+    def sysap_id(self, value):
+        """ setter sysap_id   """
+        self._sysap_id = value
+
     async def connect(self):
         """ connect to the Free@Home sysap   """
         settings = SettingsFah(self._host)
@@ -1007,6 +1021,7 @@ class FreeAtHomeSysApp(object):
             # create xmpp client
             self.xmpp = Client(self._jid, self._password, self._host, self._port, fahversion, iterations, salt, self.reconnect, self._component_path)
             self.xmpp.auth_failed_callback = self.auth_failed_callback
+            self.xmpp.sysap_id = self._sysap_id
             # connect
             self.xmpp.sysap_connect()
 

--- a/custom_components/freeathome/light.py
+++ b/custom_components/freeathome/light.py
@@ -83,7 +83,7 @@ class FreeAtHomeLight(LightEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.light_device.serialnumber + '/' + self.light_device.channel_id
+        return self.light_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/lock.py
+++ b/custom_components/freeathome/lock.py
@@ -42,7 +42,7 @@ class FreeAtHomeLock(LockEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.lock_device.serialnumber + '/' + self.lock_device.channel_id
+        return self.lock_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/migration.py
+++ b/custom_components/freeathome/migration.py
@@ -1,0 +1,65 @@
+"""Keep the entity id when the unique id of a virtual device changes."""
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+# The entity domain, the type get_devices expects, and the suffix the platform
+# appends. Only climate and the thermostat temperature sensor differ from the
+# plain mapping, so the table stays next to the loop that reads it.
+SOURCES = (
+    ("binary_sensor", "binary_sensor", ""),
+    ("climate", "thermostat", ""),
+    ("cover", "cover", ""),
+    ("light", "light", ""),
+    ("lock", "lock", ""),
+    ("scene", "scene", ""),
+    ("sensor", "sensor", ""),
+    ("sensor", "thermostat", "/current_temperature"),
+    ("switch", "switch", ""),
+)
+
+
+def migrate_unique_ids(registry, sysap, integration):
+    """Rename registry entries whose unique id gained the SysAP in front.
+
+    Renaming keeps the entity id, and with it the history, the area and every
+    automation that points at the entity. Adding the entity under the new
+    unique id without this step would hand out a fresh entity id instead.
+
+    Runs before the platforms are set up, so every entity is added under the
+    id it will keep.
+    """
+    for entity_domain, device_type, suffix in SOURCES:
+        for device in sysap.get_devices(device_type):
+            old_unique_id = device.lookup_key + suffix
+            new_unique_id = device.unique_id + suffix
+            if old_unique_id == new_unique_id:
+                continue
+
+            entity_id = registry.async_get_entity_id(
+                entity_domain, integration, old_unique_id
+            )
+            if entity_id is None:
+                continue
+
+            if registry.async_get_entity_id(
+                entity_domain, integration, new_unique_id
+            ):
+                # Another SysAP was here first and keeps the entity id. This
+                # device is added under a fresh one, where it used to be
+                # dropped as a duplicate.
+                _LOGGER.info(
+                    "Unique id %s is taken, %s keeps its own entity",
+                    new_unique_id,
+                    old_unique_id,
+                )
+                continue
+
+            _LOGGER.info(
+                "Migrating unique id of %s from %s to %s",
+                entity_id,
+                old_unique_id,
+                new_unique_id,
+            )
+            registry.async_update_entity(entity_id, new_unique_id=new_unique_id)

--- a/custom_components/freeathome/scene.py
+++ b/custom_components/freeathome/scene.py
@@ -47,7 +47,7 @@ class FreeAtHomeScene(Scene):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.scene_device.serialnumber + '/' + self.scene_device.channel_id
+        return self.scene_device.unique_id
 
     async def async_added_to_hass(self):
         """Register callback to update hass after device was changed."""

--- a/custom_components/freeathome/sensor.py
+++ b/custom_components/freeathome/sensor.py
@@ -145,7 +145,7 @@ class FreeAtHomeSensor(SensorEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.sensor_device.lookup_key
+        return self.sensor_device.unique_id
 
     @property
     def should_poll(self):
@@ -219,7 +219,7 @@ class FreeAtHomeThermostatTemperatureSensor(SensorEntity):
 
     @property
     def unique_id(self):
-        return f"{self.sensor_device.serialnumber}/{self.sensor_device.channel_id}/current_temperature"
+        return f"{self.sensor_device.unique_id}/current_temperature"
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/switch.py
+++ b/custom_components/freeathome/switch.py
@@ -44,7 +44,7 @@ class FreeAtHomeSwitch(SwitchEntity):
     @property
     def unique_id(self):
         """Return the ID """
-        return self.switch_device.serialnumber + '/' + self.switch_device.channel_id
+        return self.switch_device.unique_id
 
     @property
     def should_poll(self):

--- a/custom_components/freeathome/tests/common.py
+++ b/custom_components/freeathome/tests/common.py
@@ -18,3 +18,4 @@ def init_client_state(client, *args, **kwargs):
     client.monitored_datapoints = {}
     client.monitored_parameters = {}
     client._update_handlers = []
+    client.sysap_id = ""

--- a/custom_components/freeathome/tests/test_unique_id.py
+++ b/custom_components/freeathome/tests/test_unique_id.py
@@ -1,0 +1,145 @@
+import pytest
+pytestmark = pytest.mark.asyncio
+
+import os
+import logging
+from async_mock import patch, AsyncMock
+
+from fah.pfreeathome import Client
+from migration import migrate_unique_ids
+from common import load_fixture, init_client_state
+
+LOG = logging.getLogger(__name__)
+
+INTEGRATION = "freeathome"
+SYSAP = "ABB700D00001"
+
+
+def get_client(sysap_id=SYSAP):
+    client = Client()
+    client.set_datapoint = AsyncMock()
+    client._host = "localhost"
+    client.component_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    client.sysap_id = sysap_id
+
+    return client
+
+
+class FakeRegistry:
+    """The two calls of the entity registry that the migration uses.
+
+    Rejects a unique id that is already taken, just like the real registry.
+    """
+
+    def __init__(self, entries=None):
+        # {(entity domain, integration, unique id): entity id}
+        self.entries = dict(entries or {})
+        self.updates = []
+
+    def async_get_entity_id(self, entity_domain, integration, unique_id):
+        return self.entries.get((entity_domain, integration, unique_id))
+
+    def async_update_entity(self, entity_id, new_unique_id):
+        key = next(k for k, v in self.entries.items() if v == entity_id)
+        if (key[0], key[1], new_unique_id) in self.entries:
+            raise ValueError("unique id %s already registered" % new_unique_id)
+        del self.entries[key]
+        self.entries[(key[0], key[1], new_unique_id)] = entity_id
+        self.updates.append((entity_id, new_unique_id))
+
+
+@pytest.fixture(autouse=True)
+def mock_init():
+    with patch("fah.pfreeathome.Client.__init__", init_client_state):
+        yield
+
+@pytest.fixture(autouse=True)
+def mock_roomnames():
+    with patch("fah.pfreeathome.get_room_names", return_value={"00":{"00":"room1", "01":"room2"}}):
+        yield
+
+
+@patch("fah.pfreeathome.Client.get_config", return_value=load_fixture("scene.xml"))
+class TestVirtualDeviceUniqueId:
+    async def test_virtual_device_gets_the_sysap_in_front(self, _):
+        client = get_client()
+        await client.find_devices(True)
+
+        scene = next(el for el in client.get_devices("scene")
+                     if el.lookup_key == "FFFF4800000F/ch0000")
+
+        assert scene.unique_id == SYSAP + "/FFFF4800000F/ch0000"
+        # The lookup key stays what the SysAP itself uses.
+        assert scene.lookup_key == "FFFF4800000F/ch0000"
+
+    async def test_virtual_device_without_a_sysap_keeps_the_plain_key(self, _):
+        client = get_client(sysap_id="")
+        await client.find_devices(True)
+
+        scene = next(el for el in client.get_devices("scene")
+                     if el.lookup_key == "FFFF4800000F/ch0000")
+
+        assert scene.unique_id == "FFFF4800000F/ch0000"
+
+    async def test_migration_renames_the_registry_entry(self, _):
+        client = get_client()
+        await client.find_devices(True)
+        registry = FakeRegistry({
+            ("scene", INTEGRATION, "FFFF4800000F/ch0000"): "scene.eigene_szene",
+        })
+
+        migrate_unique_ids(registry, client, INTEGRATION)
+
+        assert registry.updates == [
+            ("scene.eigene_szene", SYSAP + "/FFFF4800000F/ch0000"),
+        ]
+        # The entity id is what automations point at, it has to survive.
+        assert registry.async_get_entity_id(
+            "scene", INTEGRATION, SYSAP + "/FFFF4800000F/ch0000"
+        ) == "scene.eigene_szene"
+
+    async def test_migration_leaves_a_taken_unique_id_alone(self, _):
+        client = get_client()
+        await client.find_devices(True)
+        registry = FakeRegistry({
+            ("scene", INTEGRATION, "FFFF4800000F/ch0000"): "scene.eigene_szene",
+            ("scene", INTEGRATION, SYSAP + "/FFFF4800000F/ch0000"): "scene.andere_szene",
+        })
+
+        migrate_unique_ids(registry, client, INTEGRATION)
+
+        assert registry.updates == []
+
+    async def test_migration_skips_an_unknown_entity(self, _):
+        client = get_client()
+        await client.find_devices(True)
+        registry = FakeRegistry()
+
+        migrate_unique_ids(registry, client, INTEGRATION)
+
+        assert registry.updates == []
+
+
+@patch("fah.pfreeathome.Client.get_config",
+       return_value=load_fixture("100C_sensor_actuator_1gang.xml"))
+class TestRealDeviceUniqueId:
+    async def test_real_device_keeps_its_unique_id(self, _):
+        client = get_client()
+        await client.find_devices(True)
+
+        light = next(iter(client.get_devices("light")))
+
+        assert light.unique_id == light.lookup_key
+        assert light.unique_id.startswith("ABB700D12345/")
+
+    async def test_migration_does_not_touch_real_devices(self, _):
+        client = get_client()
+        await client.find_devices(True)
+        light = next(iter(client.get_devices("light")))
+        registry = FakeRegistry({
+            ("light", INTEGRATION, light.lookup_key): "light.lampe",
+        })
+
+        migrate_unique_ids(registry, client, INTEGRATION)
+
+        assert registry.updates == []


### PR DESCRIPTION
Follow-up to #305. With the device state separated per client, it is now possible to tell which SysAP a device came from, which is what this change needs.

**The problem**

Virtual devices, so light groups, scenes and the "all lamps" entry, do not sit on the bus. Every SysAP hands out the same `FFFF...` serial number for them. With two SysAPs the second entry therefore tries to add entities under unique ids the first one already took, and Home Assistant drops them with "does not generate unique IDs". On my installation this is one remaining error per restart, for `light.alle_lampen` (`FFFF40000002`).

Real devices are not affected. They carry a hardware serial (`ABB...`, `7EB...`, `E11...`) that is unique across SysAPs. On my system 90 of 93 serial numbers are real ones, so this touches a handful of entities per installation, not all of them.

**The change**

`FahDevice.unique_id` puts the SysAP in front of the lookup key, but only for a `FFFF...` serial. Everything else keeps exactly the unique id it has today. The SysAP is identified by the unique id of the config entry, so it survives a change of IP address.

`migration.py` renames the affected registry entries before the platforms are set up. Renaming keeps the entity id, so history, area and every automation pointing at the entity survive. Adding the entity under a new unique id without this step would hand out a fresh entity id instead, and that would break automations.

**Left out on purpose**

The device registry is untouched. Two SysAPs still share one device entry for their virtual devices, because `device_info` identifies them by the bare serial number. That costs a shared device card, no entity. Splitting it as well would need a device registry migration on top.

**Tests**

Seven new tests in `tests/test_unique_id.py`. The full suite passes.
